### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Below, you will find example flows for each method.
     *Note:* Okay, so, about that automagically... Here's what happens behind the scenes: Let's say your website is `https://my-amazing-app.com`. Following the OAuth flow the user is redirected to a Smartcar-hosted redirect URI `https://javascript-sdk.smartcar.com/redirect-2.0.0?app_origin=https://my-amazing-app.com&code={authorization-code}`. This page sources `redirect.js` which uses `postMessage` to send a message with the authorization code or error to the origin specified by the `app_origin` query param `https://my-amazing-app.com`. The redirect page then closes itself out. On `https://my-amazing-app.com` the Smartcar instance you created receives the posted message and fires your `onComplete` method with the appropriate arguments. From your user's perspective, all they'll see is a brief flicker of the redirect page before it closes out, depending on their connection speed.
 5. Your application's back end server will need to accept the authorization code and exchange it for an access token.
 
-For a more detailed explanation of our Smartcar-hosted redirect scheme see our [blog post](TODO: LINK HERE) on the topic.
-
 #### Self-Hosted
 
 Here's an example flow for the case that you host the redirect yourself (many of the steps remain similar):
@@ -126,16 +124,13 @@ if (error) {
 }
 ```
 
-<!-- TODO: why show state and forcePrompt in this? just seems to add unnecessary disclaimers -->
-<!-- TODO: give examples of usage for each instance method -->
-
 Once initialized there are three instance methods for setting up the OAuth flow:
 
 - `openDialog()` - to open the Smartcar OAuth dialog directly
 - `addClickHandler({id})` - to add a click handler to an HTML element that will open the Smartcar OAuth dialog
 - `generateLink()` - to generate the bare Smartcar OAuth URL
 
-See the [reference below](TODO: link to appropriate section) for detailed signature information.
+See the [reference below](#configuration) for detailed signature information.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,73 @@
 # Smartcar JS Client SDK [![Build Status][ci-image]][ci-url] [![GitHub tag][tag-image]][tag-url]
 
-The official Smartcar Javascript SDK
+The official Smartcar JavaScript SDK
 
 ## Overview
 
 Smartcar is the connected car [API](https://smartcar.com/docs) that allows mobile and web apps to communicate with connected vehicles across brands (think “check odometer” or “unlock doors.”)
 
-To make requests to a vehicle from a web application the end user must connect their vehicle using [Smartcar's authorization flow](https://smartcar.com/docs#authentication). The Smartcar Javascript SDK provides two scripts that assist with running this flow.
+To make requests to a vehicle from a web application, the end user must connect their vehicle using [Smartcar's authorization flow](https://smartcar.com/docs#authentication). The Smartcar JavaScript SDK provides two scripts that assist with running this flow.
 
-- `sdk.js`: Sourced on the page your authorization flow begins from. Attaches to the browser's window as `Smartcar`. Allows you to generate a Smartcar OAuth URL and launch Smartcar's authorization flow in a pop-up.
-- `redirect.js`: Sourced on redirect page following completion of OAuth flow. Runs on load. This *optional* file can be served in the last page of your OAuth flow to close the popup window and trigger firing of an optional `onComplete` method passed to the `Smartcar` constructor from `sdk.js`. If you use a Smartcar-hosted redirect (explained in greater detail below) this file is automatically served and the `onComplete` method becomes required.
+- `sdk.js`: Sourced on the page on which your authorization flow begins. Attaches to the browser's window as `Smartcar`. Allows you to generate a Smartcar OAuth URL and to launch Smartcar's authorization flow in a pop-up.
+- `redirect.js`: Sourced on redirect page following completion of OAuth flow. Runs on load. This *optional* file can be served in the last page of your OAuth flow to close the pop-up window and trigger firing of an optional `onComplete` method passed to the `Smartcar` constructor from `sdk.js`. If you use a Smartcar-hosted redirect (explained in greater detail below), this file is automatically served and the `onComplete` method becomes required.
 
 For more information about Smartcar's authorization flow, please visit our [API documentation](https://smartcar.com/docs#authentication).
 
 ## Why Use This
 
-This SDK facilitates OAuth link generation, click handler creation and popup dialog creation. A user must authenticate their vehicles with your application to use it. Smartcar handles the majority of this process but you need to handle launching the authentication flow and handling the redirect following completion of the flow.
+This SDK facilitates OAuth link generation, click handler creation, and pop-up dialog creation. A user must authenticate their vehicles with your application to use it. Smartcar handles the majority of this process, but you need to handle the launch of the authentication flow and the redirect after completion of the flow.
 
-This SDK provides functions that assist in launching the authentication flow. Additionally, the `redirect.js` script helps in extracting the authorization code from a redirect.
+This SDK provides functions that assist in launching the authentication flow. Additionally, the `redirect.js` script helps extract the authorization code from a redirect.
 
-In conjunction with this SDK, Smartcar simplify redirect handling through Smartcar-hosted redirects. If you use a Smartcar-hosted redirect we handle extracting the authorization code and call an `onComplete` function you provide on the client with the code.
+In conjunction with this SDK, Smartcar simplifies redirect handling through Smartcar-hosted redirects. If you use a Smartcar-hosted redirect, we handle extracting the authorization code, and then pass it to an `onComplete` function, which you provide.
 
 ## Quick Start
 
-Before integrating with Smartcar's SDK, you'll need to register an application in the [Smartcar Developer portal](https://dashboard.smartcar.com).
+Before integrating with Smartcar's SDK, you'll need to register an application in the [developer dashboard](https://dashboard.smartcar.com).
 
-You have a choice of using a Smartcar-hosted redirect or hosting your own. This choice is made when you add redirect URIs in the developer dashboard and influences how you use this SDK. As a developer there are several key differences between the two strategies.
+You have the choice between using a Smartcar-hosted redirect or hosting your own. This choice is made when you add redirect URIs in the developer dashboard, and it influences how you use this SDK. There are several key differences between the two strategies.
 
-First, if you use Smartcar hosting you will add a redirect URI to your application of the form `https://javascript-sdk.smartcar.com/redirect-{version}?app_origin={your-client-origin-here}`. So for example, if your client was served at `https://my-awesome-app.com` you'd add the following redirect URI to your app in the dashboard: `https://javascript-sdk.smartcar.com/redirect-2.0.0?app_origin=https://my-awesome-app.com`. Note: this value is only your app's origin. If your client was served at `https://my-awesome-app.com/application` you would add the same example redirect URI leaving the `/application` in the `app_origin`. This `app_origin` URL (your client) must be either an HTTP localhost or HTTPS URL. See the [Register](https://smartcar.com/docs#redirect-uris) section of our docs for valid formats.
+First, if you choose a Smartcar-hosted redirect you will add a redirect URI of the form `https://javascript-sdk.smartcar.com/redirect-{version}?app_origin={your-client-origin-here}` to your application. For example, if your client is served at `https://my-awesome-app.com` you will add the following redirect URI to your app in the dashboard: `https://javascript-sdk.smartcar.com/redirect-2.0.0?app_origin=https://my-awesome-app.com`. Note: this value is only your app's origin. If your client is served at `https://my-awesome-app.com/application` you will add the same example redirect URI, leaving out the `/application` in the `app_origin`. This `app_origin` URL (your client) must be either an HTTP localhost or HTTPS URL. See the [Register](https://smartcar.com/docs#redirect-uris) section of our docs for valid formats.
 
-Second, if you use Smartcar hosting you must provide an `onComplete` function with the following signature `onComplete(error, code, [state])` to the Smartcar constructor. This `onComplete` method will be called when the user completes the authorization flow. If they approved access you'll need to exchange the `code` parameter for an access token. If they denied access you'll need to handle the error (passed in the `error` argument).
+Secondly, if you choose a Smartcar-hosted redirect, you must also provide an `onComplete` function with the signature `onComplete(error, code, [state])` to the Smartcar constructor. This `onComplete` method will be called when the user completes the authorization flow. If they approve access you'll need to exchange the `code` parameter for an access token. If they deny access you'll need to handle the error (which is passed in the `error` argument).
 
-If you host the redirect yourself you can provide any valid redirect URI (see the [Register](https://smartcar.com/docs#redirect-uris) section of our docs) and `onComplete` is optional. You may source `redirect.js` in your redirect popup to close out the window and trigger firing of the `onComplete` (if you've provided one to the `Smartcar` constructor).
+If you decide to host the redirect yourself, you can provide any valid redirect URI (see the [Register](https://smartcar.com/docs#redirect-uris) section of our docs) and `onComplete` is optional. You may source `redirect.js` in your redirect pop-up to close out the window and trigger firing of the `onComplete` (if you've provided one to the `Smartcar` constructor).
 
-Below are example flows for each method.
+Below, you will find example flows for each method.
 
 ### Example Flows
 
-#### Smartcar-hosted
+#### Smartcar-Hosted
 
-1. User clicks "Connect your car" button (or similar) on your application's website.
+1. User clicks "Connect your car" button (or similar button) on your application's website.
 2. User is redirected to an OAuth authentication page, using the `openDialog` or `addClickHandler` methods. This page requires the user to authenticate with their vehicle credentials.
 
-    *Note:* due to the implementation of `redirect.js`, the redirect page must be opened in a separate window.
-3. After entering credentials the user will be presented with a list of their vehicles to authorize and a selection of permissions to grant your app.
-4. Once the user has selected their vehicle & selected permissions, this SDK will automagically trigger the `onComplete` function you provide with the authorization code or an error. If called with a code you must send this code to your backend to then exchange with Smartcar for an access token.
+    *Note:* Due to the implementation of `redirect.js`, the redirect page must be opened in a separate window.
+3. After entering their credentials, the user will be presented with a list of their vehicles to authorize and a selection of permissions to grant your app.
+4. Once the user has selected their vehicle and selected permissions, this SDK will automagically trigger the `onComplete` function you provide with the authorization code or an error. If called with a code, you must send this code to your back end to then exchange it with Smartcar for an access token.
 
-    *Note:* Okay so about that automagically. Here's what happens behind the scenes. Let's say your website is `https://my-amazing-app.com`. Following the OAuth flow the user is redirected to the Smartcar-hosted redirect URI - `https://javascript-sdk.smartcar.com/redirect-2.0.0?app_origin=https://my-amazing-app.com&code={authorization-code}`. This page sources `redirect.js` which uses `postMessage` to send a message with the authorization code or error to the origin specified by the `app_origin` query param - `https://my-amazing-app.com`. The redirect page then closes itself out. On `https://my-amazing-app.com` the Smartcar instance you created receives the posted message and fires your `onComplete` method with the appropriate arguments. From your user's perspective all they'll see is a brief flicker of the redirect page before it closes out depending on their connection speed.
-5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
+    *Note:* Okay, so, about that automagically... Here's what happens behind the scenes: Let's say your website is `https://my-amazing-app.com`. Following the OAuth flow the user is redirected to a Smartcar-hosted redirect URI `https://javascript-sdk.smartcar.com/redirect-2.0.0?app_origin=https://my-amazing-app.com&code={authorization-code}`. This page sources `redirect.js` which uses `postMessage` to send a message with the authorization code or error to the origin specified by the `app_origin` query param `https://my-amazing-app.com`. The redirect page then closes itself out. On `https://my-amazing-app.com` the Smartcar instance you created receives the posted message and fires your `onComplete` method with the appropriate arguments. From your user's perspective, all they'll see is a brief flicker of the redirect page before it closes out, depending on their connection speed.
+5. Your application's back end server will need to accept the authorization code and exchange it for an access token.
 
 For a more detailed explanation of our Smartcar-hosted redirect scheme see our [blog post](TODO: LINK HERE) on the topic.
 
 #### Self-Hosted
 
-Here's an example flow should you host the redirect yourself (many of the steps remain similar):
+Here's an example flow for the case that you host the redirect yourself (many of the steps remain similar):
 
-1. User clicks "Connect your car" button (or similar) on your application's website.
-2. User is redirected to an OAuth authentication page, using the `openDialog`, `addClickHandler` or `generateLink` methods. This page requires the user to authenticate with their vehicle credentials.
-3. After entering credentials the user will be presented with a list of their vehicles to authorize and a selection of permissions to allow your app.
-4. Smartcar's services will redirect back to your application's redirect URI. The redirect URI will include a `code` query parameter holding the authorization code if the user approved the authorization. If they denied access the URI will include `error` & `error_description` parameters. If you source `redirect.js` on your redirect page it will trigger execution of your optionally provided `onComplete` method (passed to the `Smartcar` constructor on the client) and close out the redirect page.
+1. User clicks "Connect your car" button (or similar button) on your application's website.
+2. User is redirected to an OAuth authentication page, using the `openDialog`, `addClickHandler`, or `generateLink` methods. This page requires the user to authenticate with their vehicle credentials.
+3. After entering their credentials, the user will be presented with a list of their vehicles to authorize and a selection of permissions to grant your app.
+4. Smartcar's services will redirect back to your application's redirect URI. If the user approves the authorization, the redirect URI will include a `code` query parameter holding the authorization code. If they deny access, the URI will include `error` and `error_description` parameters. If you source `redirect.js` on your redirect page, it will trigger execution of your optionally provided `onComplete` method (passed to the `Smartcar` constructor on the client) and close out the redirect page.
 
-    *Note:* in the Smartcar-hosted scheme `redirect.js` handles extracting the query parameters from the redirect URI. In a manual hosting scheme you can choose to do this extraction client side (making use of `redirect.js` if you'd like) or server side. If they approved access you'll need to exchange the `code` parameter for an access token. If they denied access you'll need to handle the error (passed in the `error` argument).
-5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
+    *Note:* in the Smartcar-hosted scheme, `redirect.js` handles extracting the query parameters from the redirect URI. In a manual hosting scheme, you can choose to do this extraction client side (making use of `redirect.js` if you'd like) or the server side. If the user approves access, you'll need to exchange the `code` parameter for an access token. If they deny access, you'll need to handle the error (passed as the first argument).
+5. Your application's back end server will need to accept the authorization code and exchange it for an access token.
 
 ## Next Steps
 
-This SDK facilitates OAuth link generation, click handler creation and popup dialog creation. This SDK will not assist in exchanging authorization codes for an access token. Should you choose to self-host the redirect this SDK will not assist with extracting the authorization code query parameter from the redirect URI.
+This SDK facilitates OAuth link generation, click handler creation, and pop-up dialog creation. This SDK will not assist in exchanging authorization codes for an access token. If you choose to self-host the redirect, this SDK provdes a script you can source on the redirect that will assist you with extracting the authorization code query parameter.
 
-See the links below to various SDKs for help in exchanging the authorization code for an access token. If the backend language you want to use isn't listed below you can still use Smartcar you'll just have to make HTTP requests manually based on our [API specification](https://smartcar.com/docs#get-all-vehicles).
+See the links below to various SDKs that can help you exchange the authorization code for an access token. If the back end language you want to use isn't listed below, you can still use the Smartcar API. You will just have to make HTTP requests manually based on our [API specification](https://smartcar.com/docs#get-all-vehicles).
 
 - [Node](https://github.com/smartcar/node-sdk)
 - [Python](https://github.com/smartcar/python-sdk)
@@ -77,7 +77,7 @@ See the links below to various SDKs for help in exchanging the authorization cod
 
 ### Import `sdk.js`
 
-Import `sdk.js` on your client. Call the `Smartcar` constructor then use one of its instance methods to setup the authorization flow.
+Import `sdk.js` on your client. Call the `Smartcar` constructor. Then use one of the constructor's instance methods to set up the authorization flow.
 
 ```html
 <script src="https://javascript-sdk.smartcar.com/sdk-2.0.0.js"></script>
@@ -93,13 +93,13 @@ const smartcar = new Smartcar({
   redirectUri: `your-redirect-uri`,
   // optional, defaults to all scopes
   scope: ['read_vehicle_info', 'read_odometer'],
-  // if using smartcar hosting this is required and must take at least two
+  // if using smartcar-hosting this is required and must take at least two
   // arguments - error & code
   // otherwise optional (will be called with the same arguments but is not
   // required to handle them)
   onComplete: function(error, code, [state]) {
     // actions to take on completion of auth flow
-    // if using smartcar hosting this should send the code to your backend
+    // if using smartcar-hosting this should send the code to your back end
     // server to exchange for an access token
   },
   development: false, // optional, defaults to false
@@ -164,14 +164,14 @@ Automatically sourced if you use a Smartcar-hosted redirect.
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
 | `clientId`      | String |Application clientId obtained from [Smartcar Developer Portal](https://dashboard.smartcar.com). |
-| `redirectUri`   | String |**Required** Redirect URI set in [application settings](https://dashboard.smartcar.com/apps). Given URI must match URI in application settings. To use Smartcar hosting this URI must be of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=<your client URI here>` |
-| `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
+| `redirectUri`   | String |**Required** Redirect URI set in [application settings](https://dashboard.smartcar.com/apps). Given URI must match URI in application settings. To use Smartcar-hosting, this URI must be of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=<your client URI here>` |
+| `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names can be found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
 | `onComplete`      | Function |**Optional** Function to be invoked on completion of the Smartcar authorization flow. This function will only be invoked if `redirect.js` is loaded in the page served at your redirect URI. |
 | `development`   | Boolean |**Optional** Launch Smartcar auth in development mode to enable the mock vehicle brand. |
 
 ### `generateLink({options})`
 
-*Note:* due to the implementation of `redirect.js`, the redirect page **must** be opened in a separate window.
+*Note:* Due to the implementation of `redirect.js`, the redirect page **must** be opened in a separate window.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here's an example flow for the case that you host the redirect yourself (many of
 
 ## Next Steps
 
-This SDK facilitates OAuth link generation, click handler creation, and pop-up dialog creation. This SDK will not assist in exchanging authorization codes for an access token. If you choose to self-host the redirect, this SDK provdes a script you can source on the redirect that will assist you with extracting the authorization code query parameter.
+This SDK facilitates OAuth link generation, click handler creation, and pop-up dialog creation. This SDK will not assist in exchanging authorization codes for an access token. If you choose to self-host the redirect, this SDK provides a script, which you can source on the redirect. The script will assist in extracting the authorization code query parameter.
 
 See the links below to various SDKs that can help you exchange the authorization code for an access token. If the back end language you want to use isn't listed below, you can still use the Smartcar API. You will just have to make HTTP requests manually based on our [API specification](https://smartcar.com/docs#get-all-vehicles).
 
@@ -130,7 +130,7 @@ Once initialized there are three instance methods for setting up the OAuth flow:
 - `addClickHandler({id})` - to add a click handler to an HTML element that will open the Smartcar OAuth dialog
 - `generateLink()` - to generate the bare Smartcar OAuth URL
 
-See the [reference below](#configuration) for detailed signature information.
+See the [reference below](https#configuration) for detailed signature information.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The official Smartcar Javascript SDK
 
 The [Smartcar API](https://smartcar.com/docs) lets you read vehicle data (location, odometer) and send commands (lock, unlock) to connected vehicles using HTTP requests.
 
-<!-- do we want to mention mobile here? in my mind just muddies the waters -->
-To make requests to a vehicle from a web or mobile application, the end user must connect their vehicle using [Smartcar's authorization flow](https://smartcar.com/docs#authentication). The Smartcar Javascript SDK provides two scripts that assist with running Smartcar's authorization flow.
+To make requests to a vehicle from a web application the end user must connect their vehicle using [Smartcar's authorization flow](https://smartcar.com/docs#authentication). The Smartcar Javascript SDK provides two scripts that assist with running Smartcar's authorization flow.
 
 - `sdk.js`: Sourced on the page your authorization flow begins from. Attaches to the browser's window as `Smartcar`. Allows you to generate a Smartcar OAuth URL and launch Smartcar's authorization flow in a pop-up.
 - `redirect.js`: Sourced on redirect page following completion of OAuth flow. Runs on load. This *optional* file can be served in the last page of your OAuth flow to close the popup window and trigger firing of an optional `onComplete` method passed to the `Smartcar` constructor from `sdk.js`. If you use a Smartcar hosted redirect (explained in greater detail below) this file is automatically served and the `onComplete` method becomes required.
@@ -16,18 +15,15 @@ For more information about Smartcar's authorization flow, please visit our [API 
 
 ## Quick Start
 
-<!-- TODO: where are supported brands listed in the dashboard? -->
-
-Before integrating with Smartcar's SDK, you'll need to register an application in the [Smartcar Developer portal](https://dashboard.smartcar.com). Supported brands are listed in this dashboard.
+Before integrating with Smartcar's SDK, you'll need to register an application in the [Smartcar Developer portal](https://dashboard.smartcar.com).
 
 The SDK helps ease the [OAuth authorization process](https://tools.ietf.org/html/rfc6749#section-4.1).
 
 We offer a choice of using a Smartcar hosted redirect or hosting your own. This choice is made when you add redirect URIs in the developer dashboard and influences how you use this SDK. As a developer there are several key differences between the two strategies.
 
-<!-- do we prefer the `${}` form of indicating user written content or something else like <your-client-uri-here> -->
-First, if you use `Smartcar` hosting you will add a redirect URI to your application of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=${your-client-uri-here}`. So for example, if your application URI was `https://my-awesome-app.com` you'd add the following redirect URI to your app in the dashboard: `https://javascript-sdk.smartcar.com/redirect?app_origin=https://my-awesome-app.com`. Note, this value is only your app's origin, if your application was at `https://my-awesome-app.com/application` you would still have the example redirect URI listed without the `/application`. Any restrictions on normal redirect URIs (like requiring `https` when not using `localhost` still apply to the value you give for `app_origin`). See the [Register](https://smartcar.com/docs#register) section of our docs for valid formats.
+First, if you use Smartcar hosting you will add a redirect URI to your application of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=<your-client-uri-here>`. So for example, if your application URI was `https://my-awesome-app.com` you'd add the following redirect URI to your app in the dashboard: `https://javascript-sdk.smartcar.com/redirect?app_origin=https://my-awesome-app.com`. Note, this value is only your app's origin, if your application was at `https://my-awesome-app.com/application` you would still have the example redirect URI listed without the `/application`. Any restrictions on normal redirect URIs (like requiring `https` when not using `localhost` still apply to the value you give for `app_origin`). See the [Register](https://smartcar.com/docs#register) section of our docs for valid formats.
 
-Second, if you `Smartcar` hosting you must provide an `onComplete` function with the following signature `onComplete(err, code, state <optional>)` to the Smartcar constructor. This `onComplete` method will be called when the user completes the authorization flow. If they approved access you'll need to exchange the `code` parameter for an access token, otherwise you'll need to handle the given `err` parameter holding the error.
+Second, if you use Smartcar hosting you must provide an `onComplete` function with the following signature `onComplete(err, code, state <optional>)` to the Smartcar constructor. This `onComplete` method will be called when the user completes the authorization flow. If they approved access you'll need to exchange the `code` parameter for an access token, otherwise you'll need to handle the given `err` parameter holding the error.
 
 If you host the redirect yourself you can provide any valid redirect URI (see the [Register](https://smartcar.com/docs#register) section of our docs) and `onComplete` is optional. You may source `redirect.js` in your redirect popup to close out the window and trigger firing of the `onComplete` (if you've provided one to the `Smartcar` constructor).
 
@@ -40,7 +36,7 @@ Here are example flows for each method:
 1. User clicks "Connect your car" button (or similar) on your application's website.
 2. The user is redirected to an OAuth authentication page, using the `openDialog` or `addClickHandler` methods. This page requires the user to authenticate with their vehicle credentials. **Note**: because the Smartcar hosted redirect page uses `postMessage` to communicate the access code back to the client page the redirect page must be opened in a separate window.
 3. After entering credentials the user will be presented with a list of their vehicles to authorize and a selection of permissions to allow your app.
-4. Once they've selected their vehicles & permissions Smartcar's services will redirect to the Smartcar hosted redirect URI. This page will load `redirect.js` which will post a message to the original client page that opened the redirect. The `skd.js` script loaded on the client page handles this redirect, calling the required `onComplete` method provided to the constructor. The `onComplete` method you provided must handle an error if the user refused authorization or sending the code to your backend to exchange for an access token if the user authorized your application.
+4. Once they've selected their vehicles & permissions Smartcar's services will redirect to the Smartcar hosted redirect URI. This page will load `redirect.js` which will post a message to the original client page that opened the redirect. The `Smartcar` class instantiated on the client page handles this redirect, calling the required `onComplete` method provided to the constructor. The `onComplete` method you provided must handle an error if the user refused authorization or sending the code to your backend to exchange for an access token if the user authorized your application.
 5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
 
 <!-- depending on timing this probably won't make it to initial launch of redirect scheme -->
@@ -56,9 +52,15 @@ Here's an example flow should you host the redirect yourself (many of the steps 
 4. Smartcar's services will redirect back to your application's redirect URI. The redirect URI will include an authorization code query parameter if the user approved the authorization, an error query parameter otherwise. If you import the `redirect.js` script at the redirect URI it will trigger execution of your optionally provided `onComplete` method (passed to the `Smartcar` constructor) and close out the redirect page. **Note:** in the Smartcar hosted scheme `redirect.js` handles extracting the query parameters from the redirect URI. In a manual hosting scheme you can choose to do this extraction client (making use of `redirect.js` if you'd like) or server side.
 5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
 
-<!-- some delineation here? feels kind of loose after the two flows -->
+## Next Steps
 
 This SDK will help facilitate OAuth link generation, popup dialog creation, and Smartcar will handle user authentication and authorization. This SDK will not assist in exchanging authorization codes for an access token. Should you choose to self host the redirect this SDK will not assist with extracting the authorization code query parameter from the redirect URI.
+
+See the links below to various SDKs for help in exchanging the authorization code for an access token. If the backend language you want to use isn't listed below you can still use Smartcar you'll just have to make HTTP requests manually based on our [API specification](https://smartcar.com/docs#get-all-vehicles).
+
+- [Node](https://github.com/smartcar/node-sdk)
+- [Python](https://github.com/smartcar/python-sdk)
+- [Java](https://github.com/smartcar/java-sdk)
 
 ### Usage
 
@@ -94,26 +96,15 @@ const smartcar = new Smartcar({
 });
 ```
 
-<!-- TODO: this strikes me as odd advice? why suggest where they put the code? -->
-The best placement for the above code is just before the closing `</body>` tag.
-
 <!-- TODO: why show state and forcePrompt in this? just seems to add unnecessary disclaimers -->
 
 Once initialized there are three instance methods for setting up the OAuth flow:
 
 - `openDialog()` - to open the Smartcar OAuth dialog directly
 - `addClickHandler({id})` - to add a click handler to an HTML element that will open the Smartcar OAuth dialog
-<!-- TODO: what is this section trying to communicate? is the 'useful in a single page app...' portion still relevant? -->
-- `generateLink()` - to generate the bare Smartcar OAuth URL (useful in single page applications when redirecting to Smartcar's OAuth flow in a new tab)
+- `generateLink()` - to generate the bare Smartcar OAuth URL
 
 See the [reference below](TODO: link to appropriate section) for detailed signature information.
-
-<!-- organization of this whole section a little awkward with this ending another example of the awkwardness -->
-You may optionally embed `redirect.js` in the page that is served by your redirect URI. Upon loading, this file will trigger invocation of the `onComplete` callback specified above by posting to the client and will close out the redirect window:
-
-```html
-<script src="https://cdn.smartcar.com/javascript-sdk/callback-1.0.0.js"></script>
-```
 
 ## Installation
 
@@ -139,7 +130,7 @@ You can import this SDK into your application from Smartcar's CDN:
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
 | `clientId`      | String |Application clientId obtained from [Smartcar Developer Portal](https://dashboard.smartcar.com). |
-| `redirectUri`   | String |**Required** Redirect URI set in [application settings](https://dashboard.smartcar.com/apps). Given URL must match URL in application settings. To use Smartcar hosting this URI must be of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=${your client URI here}` |
+| `redirectUri`   | String |**Required** Redirect URI set in [application settings](https://dashboard.smartcar.com/apps). Given URL must match URL in application settings. To use Smartcar hosting this URI must be of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=<your client URI here>` |
 | `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
 | `onComplete`      | Function |**Optional** Function to be invoked on completion of the Smartcar authorization flow. This function will only be invoked if `redirect.js` is loaded in the page served at your redirect URI. |
 | `development`   | Boolean |**Optional** Launch Smartcar auth in development mode to enable the mock vehicle brand. |

--- a/README.md
+++ b/README.md
@@ -1,130 +1,191 @@
 # Smartcar JS Client SDK [![Build Status][ci-image]][ci-url] [![GitHub tag][tag-image]][tag-url]
 
-The official Smartcar Javascript SDK.
+The official Smartcar Javascript SDK
 
 ## Overview
-The [Smartcar API](https://smartcar.com/docs) lets you read vehicle data (location, odometer) and send commands to vehicles (lock, unlock) to connected vehicles using HTTP requests.
 
+The [Smartcar API](https://smartcar.com/docs) lets you read vehicle data (location, odometer) and send commands (lock, unlock) to connected vehicles using HTTP requests.
+
+<!-- do we want to mention mobile here? in my mind just muddies the waters -->
 To make requests to a vehicle from a web or mobile application, the end user must connect their vehicle using [Smartcar's authorization flow](https://smartcar.com/docs#authentication). The Smartcar Javascript SDK provides two scripts that assist with running Smartcar's authorization flow.
-- `sdk.js`: attaches to the browser's window as `Smartcar`. Allows you to generate a Smartcar OAuth URL and launch Smartcar's authorization flow in a pop-up.
-- `callback.js`: runs on load. This file is optional and can be served in the last page of your OAuth flow to close the popup window and call the callback function that was passed in when initializing `sdk.js`.
+
+- `sdk.js`: Sourced on the page your authorization flow begins from. Attaches to the browser's window as `Smartcar`. Allows you to generate a Smartcar OAuth URL and launch Smartcar's authorization flow in a pop-up.
+- `redirect.js`: Sourced on redirect page following completion of OAuth flow. Runs on load. This *optional* file can be served in the last page of your OAuth flow to close the popup window and trigger firing of an optional `onComplete` method passed to the `Smartcar` constructor from `sdk.js`. If you use a Smartcar hosted redirect (explained in greater detail below) this file is automatically served and the `onComplete` method becomes required.
 
 For more information about Smartcar's authorization flow, please visit our [API documentation](https://smartcar.com/docs#authentication).
 
 ## Quick Start
-Before integrating with Smartcar's SDK, you'll need to register an application in the [Smartcar Developer portal](https://developer.smartcar.com). If you do not have access to the dashboard, please [request access](https://smartcar.com/subscribe).
 
-The SDK helps ease the [OAuth authorization process](https://tools.ietf.org/html/rfc6749#section-4.1). A sample flow looks like this:
+<!-- TODO: where are supported brands listed in the dashboard? -->
+
+Before integrating with Smartcar's SDK, you'll need to register an application in the [Smartcar Developer portal](https://dashboard.smartcar.com). Supported brands are listed in this dashboard.
+
+The SDK helps ease the [OAuth authorization process](https://tools.ietf.org/html/rfc6749#section-4.1).
+
+We offer a choice of using a Smartcar hosted redirect or hosting your own. This choice is made when you add redirect URIs in the developer dashboard and influences how you use this SDK. As a developer there are several key differences between the two strategies.
+
+<!-- do we prefer the `${}` form of indicating user written content or something else like <your-client-uri-here> -->
+First, if you use `Smartcar` hosting you will add a redirect URI to your application of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=${your-client-uri-here}`. So for example, if your application URI was `https://my-awesome-app.com` you'd add the following redirect URI to your app in the dashboard: `https://javascript-sdk.smartcar.com/redirect?app_origin=https://my-awesome-app.com`. Note, this value is only your app's origin, if your application was at `https://my-awesome-app.com/application` you would still have the example redirect URI listed without the `/application`. Any restrictions on normal redirect URIs (like requiring `https` when not using `localhost` still apply to the value you give for `app_origin`). See the [Register](https://smartcar.com/docs#register) section of our docs for valid formats.
+
+Second, if you `Smartcar` hosting you must provide an `onComplete` function with the following signature `onComplete(err, code, state <optional>)` to the Smartcar constructor. This `onComplete` method will be called when the user completes the authorization flow. If they approved access you'll need to exchange the `code` parameter for an access token, otherwise you'll need to handle the given `err` parameter holding the error.
+
+If you host the redirect yourself you can provide any valid redirect URI (see the [Register](https://smartcar.com/docs#register) section of our docs) and `onComplete` is optional. You may source `redirect.js` in your redirect popup to close out the window and trigger firing of the `onComplete` (if you've provided one to the `Smartcar` constructor).
+
+Here are example flows for each method:
+
+### Example Flows
+
+#### Smartcar Hosted
 
 1. User clicks "Connect your car" button (or similar) on your application's website.
-2. The user is redirected to a new page, either as a popup (if using the `openDialog` and/or `addClickHandler` methods), or in the same page (if the client redirects to the link generated by `generateLink` directly, without using `openDialog` and/or `addClickHandler`). This page requires the user authenticate with their vehicle credentials.
-3. The user will be asked to authorize your application to connect to their vehicle.
-4. Smartcar's services will redirect back to your application's redirectUri. The redirect will include an authorization code if the user approved the authorization, an error otherwise. An optional callback function (passed in as `onComplete`) will be invoked if `callback.js` is imported in the page served at your application's redirectUri.
+2. The user is redirected to an OAuth authentication page, using the `openDialog` or `addClickHandler` methods. This page requires the user to authenticate with their vehicle credentials. **Note**: because the Smartcar hosted redirect page uses `postMessage` to communicate the access code back to the client page the redirect page must be opened in a separate window.
+3. After entering credentials the user will be presented with a list of their vehicles to authorize and a selection of permissions to allow your app.
+4. Once they've selected their vehicles & permissions Smartcar's services will redirect to the Smartcar hosted redirect URI. This page will load `redirect.js` which will post a message to the original client page that opened the redirect. The `skd.js` script loaded on the client page handles this redirect, calling the required `onComplete` method provided to the constructor. The `onComplete` method you provided must handle an error if the user refused authorization or sending the code to your backend to exchange for an access token if the user authorized your application.
 5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
 
-The SDK will help facilitate the OAuth link generation, popup dialog creation, and Smartcar will handle the user authentication and authorization. This SDK will not assist with the backend server code to accept authorization codes or exchanging for access tokens (step 6).
+<!-- depending on timing this probably won't make it to initial launch of redirect scheme -->
+For a more detailed explanation of our Smartcar hosted redirect scheme see our [blog post](TODO: LINK HERE?) on the topic.
 
-### Import `sdk.js`:
+#### Self Hosted
+
+Here's an example flow should you host the redirect yourself (many of the steps remain similar):
+
+1. User clicks "Connect your car" button (or similar) on your application's website.
+2. The user is redirected to an OAuth authentication page, using the `openDialog`, `addClickHandler` or `generateLink` methods. This page requires the user to authenticate with their vehicle credentials.
+3. After entering credentials the user will be presented with a list of their vehicles to authorize and a selection of permissions to allow your app.
+4. Smartcar's services will redirect back to your application's redirect URI. The redirect URI will include an authorization code query parameter if the user approved the authorization, an error query parameter otherwise. If you import the `redirect.js` script at the redirect URI it will trigger execution of your optionally provided `onComplete` method (passed to the `Smartcar` constructor) and close out the redirect page. **Note:** in the Smartcar hosted scheme `redirect.js` handles extracting the query parameters from the redirect URI. In a manual hosting scheme you can choose to do this extraction client (making use of `redirect.js` if you'd like) or server side.
+5. Your application's backend server will need to accept the authorization code and exchange it for an access token.
+
+<!-- some delineation here? feels kind of loose after the two flows -->
+
+This SDK will help facilitate OAuth link generation, popup dialog creation, and Smartcar will handle user authentication and authorization. This SDK will not assist in exchanging authorization codes for an access token. Should you choose to self host the redirect this SDK will not assist with extracting the authorization code query parameter from the redirect URI.
+
+### Usage
+
+### Import `sdk.js`
+
+Import `sdk.js` on your client. Call the `Smartcar` constructor then use one of its instance methods to setup the authorization flow.
+
 ```html
-<script src="https://cdn.smartcar.com/javascript-sdk/sdk-1.0.0.js"></script>
+<script src="https://javascript-sdk.smartcar.com/sdk-2.0.0.js"></script>
 ```
 
-### Use `sdk.js`:
+### Use `sdk.js`
+
 Initialize:
+
 ```javascript
 const smartcar = new Smartcar({
   clientId: `your-client-id`,
   redirectUri: `your-redirect-uri`,
-  scope: ['read_vehicle_info', 'read_odometer'], // optional
-  onComplete: function() { // optional
-    window.location.reload();
+  // optional, defaults to all scopes
+  scope: ['read_vehicle_info', 'read_odometer'],
+  // if using smartcar hosting this is required and must take at least two
+  // arguments - error & code
+  // otherwise optional (will be called with the same arguments but is not
+  // required to handle them)
+  onComplete: function(error, code, state <optional>) {
+    // actions to take on completion of auth flow
+    // if using smartcar hosting this should send the code to your backend
+    // server to exchange for an access token
   },
-  development: false, // optional
+  development: false, // optional, defaults to false
+  useSmartcarHostedRedirect: true, // optional, defaults to false
 });
 ```
+
+<!-- TODO: this strikes me as odd advice? why suggest where they put the code? -->
 The best placement for the above code is just before the closing `</body>` tag.
 
-To open the Smartcar OAuth dialog directly:
-```javascript
-// note: state and forcePrompt are optional
-smartcar.openDialog({state, forcePrompt});
-```
+<!-- TODO: why show state and forcePrompt in this? just seems to add unnecessary disclaimers -->
 
-To add a click handler to an HTML element that will open the Smartcar OAuth dialog:
-```javascript
-// note: state and forcePrompt are optional
-smartcar.addClickHandler({id, state, forcePrompt});
-```
+Once initialized there are three instance methods for setting up the OAuth flow:
 
-You may embed `callback.js` in the page that is served by your redirectUri. Upon loading, this file will invoke the `onComplete` callback specified above and close the window:
+- `openDialog()` - to open the Smartcar OAuth dialog directly
+- `addClickHandler({id})` - to add a click handler to an HTML element that will open the Smartcar OAuth dialog
+<!-- TODO: what is this section trying to communicate? is the 'useful in a single page app...' portion still relevant? -->
+- `generateLink()` - to generate the bare Smartcar OAuth URL (useful in single page applications when redirecting to Smartcar's OAuth flow in a new tab)
+
+See the [reference below](TODO: link to appropriate section) for detailed signature information.
+
+<!-- organization of this whole section a little awkward with this ending another example of the awkwardness -->
+You may optionally embed `redirect.js` in the page that is served by your redirect URI. Upon loading, this file will trigger invocation of the `onComplete` callback specified above by posting to the client and will close out the redirect window:
+
 ```html
 <script src="https://cdn.smartcar.com/javascript-sdk/callback-1.0.0.js"></script>
 ```
 
-To retrieve the Smartcar OAuth URL (useful in single page applications when redirecting to Smartcar's OAuth flow in a new tab):
-```javascript
-// note: state and forcePrompt are optional
-smartcar.generateLink({state, forcePrompt});
-```
-
 ## Installation
+
 You can import this SDK into your application from Smartcar's CDN:
 
 ### sdk.js
+
 ```html
 <script src="https://cdn.smartcar.com/javascript-sdk/sdk-1.0.0.js"></script>
 ```
 
-### callback.js
+### redirect.js
+
 ```html
 <script src="https://cdn.smartcar.com/javascript-sdk/callback-1.0.0.js"></script>
 ```
 
 ## Configuration
+
 ### `new Smartcar({options})`
+
 #### Options:
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
-| `clientId`      | String |Application clientId obtained from [Smartcar Developer Portal](https://developer.smartcar.com). If you do not have access to the dashboard, please [request access](https://smartcar.com/subscribe). |
-| `redirectUri`   | String |**Required** RedirectURI set in [application settings](https://developer.smartcar.com/apps). Given URL must match URL in application settings. |
+| `clientId`      | String |Application clientId obtained from [Smartcar Developer Portal](https://dashboard.smartcar.com). |
+| `redirectUri`   | String |**Required** Redirect URI set in [application settings](https://dashboard.smartcar.com/apps). Given URL must match URL in application settings. To use Smartcar hosting this URI must be of the form `https://javascript-sdk.smartcar.com/redirect?app_origin=${your client URI here}` |
 | `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
-| `onComplete`      | Function |**Optional** Function to be invoked on completion of the Smartcar authorization flow. This function will only be invoked if `callback.js` is loaded in the page served by your redirectUri. |
+| `onComplete`      | Function |**Optional** Function to be invoked on completion of the Smartcar authorization flow. This function will only be invoked if `redirect.js` is loaded in the page served at your redirect URI. |
 | `development`   | Boolean |**Optional** Launch Smartcar auth in development mode to enable the mock vehicle brand. |
 
+
+<!-- TODO: I think it might be useful to consolidate the three instance methods reference as they are so similar outside of the `id` parameter to `addClickHandler` but want to get others' thoughts before doing so -->
 ### `generateLink({options})`
-##### Example
+
+**Note:** if you use Smartcar hosting you *MUST* open the redirect page in a separate window from your client in order for `postMessage` to succeed.
+
+#### Example
+
 ```
 'https://connect.smartcar.com/oauth/authorize?response_type=token...'
 ```
 
 #### Options
+
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
-| `state`         | String |**Optional** OAuth state parameter passed to the redirectUri. This parameter may be used for identifying the user who initiated the request. |
+| `state`         | String |**Optional** OAuth state parameter passed to the redirect URI. This parameter may be used for identifying the user who initiated the request. |
 | `forcePrompt`   | Boolean |**Optional** Setting `forcePrompt` to `true` will show the permissions approval screen on every authentication attempt, even if the user has previously consented to the exact scope of permissions. |
 
 ### `openDialog({options})`
+
 #### Options
+
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
-| `state`         | String |**Optional** OAuth state parameter passed to the redirectUri. This parameter may be used for identifying the user who initiated the request. |
+| `state`         | String |**Optional** OAuth state parameter passed to the redirect URI. This parameter may be used for identifying the user who initiated the request. |
 | `forcePrompt`   | Boolean |**Optional** Setting `forcePrompt` to `true` will show the permissions approval screen on every authentication attempt, even if the user has previously consented to the exact scope of permissions. |
 
 ### `addClickHandler({options})`
+
 #### Options
+
 | Parameter       | Type | Description   |
 |:--------------- |:---|:------------- |
 | `id`         | String |**Optional** The id of the element for which to add the click handler (e.g. a "Connect your car" button). |
-| `state`         | String |**Optional** OAuth state parameter passed to the redirectUri. This parameter may be used for identifying the user who initiated the request. |
+| `state`         | String |**Optional** OAuth state parameter passed to the redirect URI. This parameter may be used for identifying the user who initiated the request. |
 | `forcePrompt`   | Boolean |**Optional** Setting `forcePrompt` to `true` will show the permissions approval screen on every authentication attempt, even if the user has previously consented to the exact scope of permissions. |
 
 ## Documentation
-Visit https://smartcar.com/docs for detailed documentation of the Smartcar API (with sample code!).
 
-## What brands are supported?
-The Smartcar API currently supports Tesla vehicles. We ship new brand support on a rolling basis and supported brands will appear automatically on the first screen of Smartcar's authentication flow. If you have any questions, drop us a line at hello@smartcar.com!
+Visit [https://smartcar.com/docs](https://smartcar.com/docs) for detailed documentation of the Smartcar API (with sample code!).
 
-[ci-url]: https://travis-ci.com/smartcar/javascript-sdk
 [ci-image]: https://travis-ci.com/smartcar/javascript-sdk.svg?token=jMbuVtXPGeJMPdsn7RQ5&branch=master
 [tag-url]: https://github.com/smartcar/javascript-sdk/tags
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg


### PR DESCRIPTION
First pass at updating SDK documentation, multiple questions as inline `TODO`s, I'll highlight the two most prominent questions/thoughts I have:

1. Do we have an in depth explanation of redirect URIs anywhere? The [`Authentication`](https://smartcar.com/docs#authentication) section of the docs seems to be where we currently point people but at least in my opinion this seems like a short section that might leave a developer with questions still. Additionally, each SDK seems to have a different description for SDKs so it seems useful to me to consolidate some of this information somewhere and have them all able to link there. If this is something people think would be helpful I'd be happy to write up a draft for a jumping off point. High level I think it'd be pretty short but basically just describe in a little more depth how redirect URIs fit into OAuth and the different schemes Smartcar uses (self hosted, Smartcar hosted, mobile app).
2. The description of the different methods of the Smartcar class seems awkward to me due to how similar their signatures/descriptions are leading to the documentation just sort of repeating itself. Added a comment or two around this but curious to see if other people think this is awkward too or if I'm imagining things.

In addition to these two there's a few other `TODO`s, would be happy to hear thoughts on those (and anything else of course). One of them mentions linking to a blog post which I'd love to still do at some point but figure won't be out by the time we want to release this. Ideally would like to do it soon after though as I think it could explain in more detail some of the complexities of this scheme and why we chose to do this (along with the potential vulnerability vector people should avoid).