### PR TITLE
Remove Smartcar hosted URI validation from SDK.

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -131,24 +131,6 @@ window.Smartcar = (function(window) {
           ' completion of authorization flow'
         );
       }
-
-      // require `app_origin` query parameter containing HTTPS served URI
-      try {
-        const searchParams = (new URL(options.redirectUri)).searchParams;
-        // `.get()` returns null if query parameter doesn't exist which will
-        // then error as null isn't a valid url
-        const appOriginUrl = new URL(searchParams.get('app_origin'));
-        if (appOriginUrl.protocol !== 'https:') {
-          throw new Error(); // throw to force descriptive error in catch
-        }
-      } catch (err) {
-        throw new Error(
-          "When using Smartcar's CDN redirect an `app_origin` query" +
-          ' parameter is required to specify the origin the extracted' +
-          ' `code` should be sent to. This `app_origin` URI must be served' +
-          ' over HTTPS'
-        );
-      }
     }
   };
 

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -66,55 +66,6 @@ describe('sdk', () => {
       }
     );
 
-    test('throws error if using Smartcar hosting w/o `app_origin`', () => {
-      expect(() => window.Smartcar({
-        redirectUri: CDN_ORIGIN,
-        clientId: 'my-id',
-        // eslint-disable-next-line no-unused-vars, no-empty-function
-        onComplete: (_, __) => {}, // stub function w/ >= 2 params
-      }))
-        .toThrow(
-          "When using Smartcar's CDN redirect an `app_origin` query parameter" +
-          ' is required to specify the origin the extracted `code` should be' +
-          ' sent to. This `app_origin` URI must be served over HTTPS'
-        );
-    });
-
-    test(
-      'throws error if using Smartcar hosting w/ invalid URL `app_origin`',
-      () => {
-        expect(() => window.Smartcar({
-          redirectUri: `${CDN_ORIGIN}/redirect?app_origin=not-a-valid-url`,
-          clientId: 'my-id',
-          // eslint-disable-next-line no-unused-vars, no-empty-function
-          onComplete: (_, __) => {}, // stub function w/ >= 2 params
-        }))
-          .toThrow(
-            "When using Smartcar's CDN redirect an `app_origin` query" +
-            ' parameter is required to specify the origin the extracted' +
-            ' `code` should be sent to. This `app_origin` URI must be served' +
-            ' over HTTPS'
-          );
-      }
-    );
-
-    test(
-      'throws error if using Smartcar hosting w/ non-HTTPS `app_origin`',
-      () => {
-        expect(() => window.Smartcar({
-          redirectUri: `${CDN_ORIGIN}/redirect?app_origin=http://not-https.com`,
-          clientId: 'my-id',
-          // eslint-disable-next-line no-unused-vars, no-empty-function
-          onComplete: (_, __) => {}, // stub function w/ >= 2 params
-        }))
-          .toThrow(
-            "When using Smartcar's CDN redirect an `app_origin` query parameter" +
-            ' is required to specify the origin the extracted `code` should be' +
-            ' sent to. This `app_origin` URI must be served over HTTPS'
-          );
-      }
-    );
-
     test('initializes correctly w/ self hosted redirect',
       () => {
         const options = {


### PR DESCRIPTION
Extensive URI validation is done on the Smartcar Dashboard. The validation here is unnecessary and was out of sync with the set of valid URI schemes Smartcar supports.