### PR TITLE
fix: fixes IE11 support, Connect popup sizing, and method documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.2.0/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.2.1/sdk.js"></script>
 ```
 
 Before v2.2.0, the SDK was versioned as follows:
@@ -192,4 +192,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.2.0
+[version]: 2.2.1

--- a/doc/README.md
+++ b/doc/README.md
@@ -62,7 +62,7 @@ Generates Smartcar OAuth URL.
 | options | <code>Object</code> |  | the link configuration object |
 | [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
-| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 **Example**
 ```js
@@ -86,7 +86,7 @@ Launches Smartcar Connect in a new window.
 | options | <code>Object</code> |  | the link configuration object |
 | [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
-| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 <a name="Smartcar+addClickHandler"></a>
 
@@ -103,7 +103,7 @@ On-click event calls openDialog when the specified element is clicked.
 | options.id | <code>String</code> |  | id of the element to add click handler to |
 | [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
-| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 <a name="Smartcar.AccessDenied"></a>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -62,7 +62,7 @@ Generates Smartcar OAuth URL.
 | options | <code>Object</code> |  | the link configuration object |
 | [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
-| [options.vehicleInfo.make] | <code>Object</code> \| <code>string</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 **Example**
 ```js
@@ -77,15 +77,16 @@ response_type=code
 <a name="Smartcar+openDialog"></a>
 
 ### smartcar.openDialog(options)
-Launches the OAuth dialog flow.
+Launches Smartcar Connect in a new window.
 
 **Kind**: instance method of [<code>Smartcar</code>](#Smartcar)
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | the link configuration object |
-| [options.state] | <code>String</code> |  | arbitrary parameter passed to redirect uri |
+| [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
+| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 <a name="Smartcar+addClickHandler"></a>
 
@@ -96,12 +97,13 @@ On-click event calls openDialog when the specified element is clicked.
 
 **Kind**: instance method of [<code>Smartcar</code>](#Smartcar)
 
-| Param | Type | Description |
-| --- | --- | --- |
-| options | <code>Object</code> | clickHandler configuration object |
-| options.id | <code>String</code> | id of the element to add click handler to |
-| [options.state] | <code>String</code> | arbitrary parameter passed to redirect uri |
-| [options.forcePrompt] | <code>Boolean</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  | clickHandler configuration object |
+| options.id | <code>String</code> |  | id of the element to add click handler to |
+| [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
+| [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
+| [options.vehicleInfo.make] | <code>Object</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 <a name="Smartcar.AccessDenied"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -28,6 +28,7 @@ class Smartcar {
    */
   constructor(options) {
     // polyfill String.prototype.startsWith for IE11 support
+    // istanbul ignore next
     if (!String.prototype.startsWith) {
       // eslint-disable-next-line no-extend-native
       String.prototype.startsWith = function(searchString, position) {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -205,7 +205,7 @@ class Smartcar {
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
    * consented to the exact scope of permission
-   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * @param {String} [options.vehicleInfo.make] - `vehicleInfo` is an
    * object with an optional property `make`, which allows users to bypass the
    * car brand selection screen. For a complete list of supported makes, please
    * see our [API Reference](https://smartcar.com/docs/api#authorization)
@@ -267,7 +267,7 @@ class Smartcar {
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
    * consented to the exact scope of permission
-   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * @param {String} [options.vehicleInfo.make] - `vehicleInfo` is an
    * object with an optional property `make`, which allows users to bypass the
    * car brand selection screen. For a complete list of supported makes, please
    * see our [API Reference](https://smartcar.com/docs/api#authorization)
@@ -290,7 +290,7 @@ class Smartcar {
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
    * consented to the exact scope of permission
-   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * @param {String} [options.vehicleInfo.make] - `vehicleInfo` is an
    * object with an optional property `make`, which allows users to bypass the
    * car brand selection screen. For a complete list of supported makes, please
    * see our [API Reference](https://smartcar.com/docs/api#authorization)

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -27,6 +27,15 @@ class Smartcar {
    * @param {Boolean} [options.testMode=false] - launch Smartcar Connect in test mode
    */
   constructor(options) {
+    // polyfill String.prototype.startsWith for IE11 support
+    if (!String.prototype.startsWith) {
+      // eslint-disable-next-line no-extend-native
+      String.prototype.startsWith = function(searchString, position) {
+        position = position || 0;
+        return this.substr(position, searchString.length) === searchString;
+      };
+    }
+
     // ensure options are well formed
     Smartcar._validateConstructorOptions(options);
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -177,10 +177,11 @@ class Smartcar {
    * @return {String} a string of window settings
    */
   static _getWindowOptions() {
-    // Sets default popup window size
+    // Sets default popup window size as percentage of screen size
+    // Note that this only applies to desktop browsers
     const windowSettings = {
-      width: 430,
-      height: 500,
+      width: window.screen.width * 0.3,
+      height: window.screen.height * 0.75,
     };
 
     const width = (window.outerWidth - windowSettings.width) / 2;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -205,7 +205,7 @@ class Smartcar {
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
    * consented to the exact scope of permission
-   * @param {Object|string} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
    * object with an optional property `make`, which allows users to bypass the
    * car brand selection screen. For a complete list of supported makes, please
    * see our [API Reference](https://smartcar.com/docs/api#authorization)
@@ -260,13 +260,18 @@ class Smartcar {
   }
 
   /**
-   * Launches the OAuth dialog flow.
+   * Launches Smartcar Connect in a new window.
    *
    * @param {Object} options - the link configuration object
-   * @param {String} [options.state] - arbitrary parameter passed to redirect uri
+   * @param {String} [options.state] - arbitrary state passed to redirect uri
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
    * consented to the exact scope of permission
+   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * object with an optional property `make`, which allows users to bypass the
+   * car brand selection screen. For a complete list of supported makes, please
+   * see our [API Reference](https://smartcar.com/docs/api#authorization)
+   * documentation.
    */
   openDialog(options) {
     const href = this.getAuthUrl(options);
@@ -281,25 +286,28 @@ class Smartcar {
    *
    * @param {Object} options - clickHandler configuration object
    * @param {String} options.id - id of the element to add click handler to
-   * @param {String} [options.state] - arbitrary parameter passed to redirect uri
-   * @param {Boolean} [options.forcePrompt] - force permission approval screen to
-   * show on every authentication, even if the user has previously consented
-   * to the exact scope of permission
+   * @param {String} [options.state] - arbitrary state passed to redirect uri
+   * @param {Boolean} [options.forcePrompt=false] - force permission approval
+   * screen to show on every authentication, even if the user has previously
+   * consented to the exact scope of permission
+   * @param {Object} [options.vehicleInfo.make] - `vehicleInfo` is an
+   * object with an optional property `make`, which allows users to bypass the
+   * car brand selection screen. For a complete list of supported makes, please
+   * see our [API Reference](https://smartcar.com/docs/api#authorization)
+   * documentation.
    */
   addClickHandler(options) {
     const id = options.id;
-    const dialogOptions = {
-      state: options.state,
-      forcePrompt: options.forcePrompt,
-    };
 
     const element = document.getElementById(id);
     if (!element) {
       throw new Error(`Could not add click handler: element with id '${id}' was not found.`);
     }
 
+    delete options.id;
+
     element.addEventListener('click', () => {
-      this.openDialog(dialogOptions);
+      this.openDialog(options);
       // this is equivalent to calling:
       // event.preventDefault();
       // event.stopPropogation();

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -728,9 +728,6 @@ describe('sdk', () => {
     };
 
     // expected OAuth link
-    const expectedLink =
-      'https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=force&scope=read_vehicle_info%20read_odometer&mode=live&state=foobarbaz';
-
     test('openDialog calls window.open', () => {
       // mock window.open
       const mockOpen = jest.fn();

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -2,6 +2,9 @@
 
 const Smartcar = require('../../dist/umd/sdk.js');
 
+const isValidWindowOptions = (str) =>
+  (/^top=[0-9.]+,left=[0-9.]+,width=[0-9.]+,height=[0-9.]+,$/).test(str);
+
 describe('sdk', () => {
   const CDN_ORIGIN = 'https://javascript-sdk.smartcar.com';
 
@@ -728,6 +731,9 @@ describe('sdk', () => {
     };
 
     // expected OAuth link
+    const expectedLink =
+    'https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=force&scope=read_vehicle_info%20read_odometer&mode=live&state=foobarbaz';
+
     test('openDialog calls window.open', () => {
       // mock window.open
       const mockOpen = jest.fn();
@@ -736,6 +742,14 @@ describe('sdk', () => {
       const smartcar = new Smartcar(options);
 
       expect(window.open).toHaveBeenCalledTimes(0);
+
+      mockOpen.mockImplementation((href, description, windowOptions) => {
+        expect(href).toEqual(expectedLink);
+        expect(description).toEqual('Connect your car');
+        expect(isValidWindowOptions(windowOptions))
+          .toBe(true, 'correctly formatted windowOptions');
+      });
+
       smartcar.openDialog(dialogOptions);
       expect(window.open).toHaveBeenCalled();
     });
@@ -787,8 +801,14 @@ describe('sdk', () => {
 
       expect(mockOpen).toHaveBeenCalledTimes(0);
 
-      document.getElementById(id).click();
+      mockOpen.mockImplementation((href, description, windowOptions) => {
+        expect(href).toEqual(expectedLink);
+        expect(description).toEqual('Connect your car');
+        expect(isValidWindowOptions(windowOptions))
+          .toBe(true, 'correctly formatted windowOptions');
+      });
 
+      document.getElementById(id).click();
       expect(mockOpen).toHaveBeenCalled();
     });
   });

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -714,26 +714,7 @@ describe('sdk', () => {
     });
   });
 
-  describe('getWindowOptions', () => {
-    test('correctly computes size of popup window', () => {
-      window.outerWidth = 1024;
-      window.outerHeight = 768;
-      window.screenX = 10;
-      window.screenY = 20;
-
-      // computed width: (1024 - 430) / 2 = 297
-      // computed height: (768 - 500) / 8 = 134
-      const expectedOptions = 'top=53.5,left=307,width=430,height=500,';
-
-      expect(Smartcar._getWindowOptions()).toBe(expectedOptions);
-    });
-  });
-
   describe('openDialog and addClickHandler', () => {
-    // computed width: (1024 - 430) / 2 = 297
-    // computed height: (768 - 500) / 8 = 134
-    const expectedOptions = 'top=53.5,left=307,width=430,height=500,';
-
     const options = {
       clientId: 'clientId',
       redirectUri: 'https://smartcar.com',
@@ -750,24 +731,16 @@ describe('sdk', () => {
     const expectedLink =
       'https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=force&scope=read_vehicle_info%20read_odometer&mode=live&state=foobarbaz';
 
-    beforeEach(() => {
-      // set window options
-      window.outerWidth = 1024;
-      window.outerHeight = 768;
-      window.screenX = 10;
-      window.screenY = 20;
-    });
-
-    test('openDialog calls window.open with correct args', () => {
+    test('openDialog calls window.open', () => {
       // mock window.open
       const mockOpen = jest.fn();
       window.open = mockOpen;
 
       const smartcar = new Smartcar(options);
 
+      expect(window.open).toHaveBeenCalledTimes(0);
       smartcar.openDialog(dialogOptions);
-
-      expect(mockOpen).toHaveBeenCalledWith(expectedLink, 'Connect your car', expectedOptions);
+      expect(window.open).toHaveBeenCalled();
     });
 
     test('addClickHandler throws error if id does not exist', () => {
@@ -819,7 +792,7 @@ describe('sdk', () => {
 
       document.getElementById(id).click();
 
-      expect(mockOpen).toHaveBeenCalledWith(expectedLink, 'Connect your car', expectedOptions);
+      expect(mockOpen).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
- IE11 does not support String.prototype.startsWith, which was used in our codebase.
    - We should investigate a longer-term fix to polyfill any ES6+ method to ES5 using Gulp, but some quick googling left me with the impression that doing so is not straightforward now that `babel-polyfill` is deprecated; therefore, I think it's best to manually polyfill for now to get a fix out.
- The Connect popup window was too small. It has been updated to be relative to your screen size.
- Adds missing documentation for options objects that are passed to `getAuthUrl()`