### PR TITLE
Remove class instantiation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 
 > NOTE: If the page serving the redirect script file does not have the original query parameters sent from Connect (`code`, `state`, `error`, `error_description`), then the `onComplete` callback will be invoked with no parameters.
 
+## Contributing
+
+When contributing to this repo, ensure that prior to your pull request you run the following commands: 
+
+`npm run readme`
+`npm run jsdoc`
 
 [ci-url]: https://travis-ci.com/smartcar/javascript-sdk
 [ci-image]: https://travis-ci.com/smartcar/javascript-sdk.svg?token=jMbuVtXPGeJMPdsn7RQ5&branch=master

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.4.0/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.4.1/sdk.js"></script>
 ```
 
 Before v2.2.0, the SDK was versioned as follows:
@@ -192,4 +192,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.4.0
+[version]: 2.4.1

--- a/README.md
+++ b/README.md
@@ -185,12 +185,6 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 
 > NOTE: If the page serving the redirect script file does not have the original query parameters sent from Connect (`code`, `state`, `error`, `error_description`), then the `onComplete` callback will be invoked with no parameters.
 
-## Contributing
-
-When contributing to this repo, ensure that prior to your pull request you run the following commands: 
-
-`npm run readme`
-`npm run jsdoc`
 
 [ci-url]: https://travis-ci.com/smartcar/javascript-sdk
 [ci-image]: https://travis-ci.com/smartcar/javascript-sdk.svg?token=jMbuVtXPGeJMPdsn7RQ5&branch=master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -131,16 +131,6 @@ class Smartcar {
    * @param {Object} options - the SDK configuration object
    */
   static _validateConstructorOptions(options) {
-    // allow only one instance of Smartcar
-    if (Smartcar._hasBeenInstantiated) {
-      throw new Error(
-        'Smartcar has already been instantiated in the window. Only one' +
-          ' instance of Smartcar can be defined.',
-      );
-    } else {
-      Smartcar._hasBeenInstantiated = true;
-    }
-
     if (!options.clientId) {
       throw new TypeError('A client ID option must be provided');
     }

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -8,10 +8,6 @@ const isValidWindowOptions = (str) =>
 describe('sdk', () => {
   const CDN_ORIGIN = 'https://javascript-sdk.smartcar.com';
 
-  beforeEach(() => {
-    Smartcar._hasBeenInstantiated = false;
-  });
-
   describe('constructor', () => {
     test('throws error if constructor called without redirectUri', () => {
       expect(() => new Smartcar({clientId: 'uuid'})).toThrow(
@@ -22,16 +18,6 @@ describe('sdk', () => {
     test('throws error if constructor called without clientId', () => {
       expect(() => new Smartcar({redirectUri: 'http://example.com'})).toThrow(
         'A client ID option must be provided',
-      );
-    });
-
-    test('throws error if smartcar already instantiated', () => {
-      // initial instantiation
-      // eslint-disable-next-line no-new
-      new Smartcar({redirectUri: 'http://example.com', clientId: 'my-id'});
-      expect(() => new Smartcar({redirectUri: 'http://example.com', clientId: 'my-id'})).toThrow(
-        'Smartcar has already been instantiated in the window. Only one' +
-          ' instance of Smartcar can be defined.',
       );
     });
 


### PR DESCRIPTION
There is not a need for an explicit check on how many times the Smartcar class has been instantiated.

This PR stems from an error that occurs when the onComplete callback is triggered with only one parameter. ReactDOM will swallow the thrown error that's triggered and run React's resetContextDependencies function to replay the event on a separate thread to verify that an error has been thrown. 

The result of this triggers a reload of the component, which then triggers the hasBeenInstantiated error.