### PR TITLE
Introduce unmount method.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ Smartcar JavaScript SDK documentation.
         * [.getAuthUrl(options)](#Smartcar+getAuthUrl) ⇒ <code>String</code>
         * [.openDialog(options)](#Smartcar+openDialog)
         * [.addClickHandler(options)](#Smartcar+addClickHandler)
+        * [.unmount()](#Smartcar+unmount)
     * _static_
         * [.AccessDenied](#Smartcar.AccessDenied) ⇐ <code>Error</code>
             * [new Smartcar.AccessDenied(message)](#new_Smartcar.AccessDenied_new)
@@ -111,6 +112,16 @@ On-click event calls openDialog when the specified element is clicked.
 | [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 | [options.singleSelect] | <code>Boolean</code> \| <code>Object</code> |  | An optional value that sets the behavior of the grant dialog displayed to the user. If set to `true`, `single_select` limits the user to selecting only one vehicle. If `single_select` is passed in as an object with the property `vin`, Smartcar will only authorize the vehicle with the specified VIN. See the [Single Select guide](https://smartcar.com/docs/guides/single-select/) for more information. |
 
+<a name="Smartcar+unmount"></a>
+
+### smartcar.unmount()
+Remove Smartcar's listeners on the global window object.
+
+The Smartcar SDK uses a global 'message' event listener to recieve the
+authorization code from the pop-up dialog. Call this method to remove the
+event listener from the global window.
+
+**Kind**: instance method of [<code>Smartcar</code>](#Smartcar)
 <a name="Smartcar.AccessDenied"></a>
 
 ### Smartcar.AccessDenied ⇐ <code>Error</code>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -348,6 +348,17 @@ class Smartcar {
       return false;
     });
   }
+
+  /**
+   * Remove Smartcar's listeners on the global window object.
+   *
+   * The Smartcar SDK uses a global 'message' event listener to recieve the
+   * authorization code from the pop-up dialog. Call this method to remove the
+   * event listener from the global window.
+   */
+  unmount() {
+    window.removeEventListener('message', this.messageHandler);
+  }
 }
 
 /**

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -990,5 +990,21 @@ describe('sdk', () => {
       document.getElementById(id).click();
       expect(mockOpen).toHaveBeenCalled();
     });
+
+    test('unmount removes the eventListener from the window object', () => {
+      const mockAddEventListener = jest.fn();
+      const mockRemoveEventListener = jest.fn();
+
+      window.addEventListener = mockAddEventListener;
+      window.removeEventListener = mockRemoveEventListener;
+
+      const smartcar = new Smartcar(options);
+      smartcar.unmount();
+
+      expect(mockAddEventListener)
+        .toHaveBeenCalledWith('message', smartcar.messageHandler);
+      expect(mockRemoveEventListener)
+        .toHaveBeenCalledWith('message', smartcar.messageHandler);
+    });
   });
 });


### PR DESCRIPTION
Add `unmount()` method to remove `message` event listener from the `window`.