### PR TITLE
Update addClickHandler and windowOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.6.0/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.7.0/sdk.js"></script>
 ```
 
 Before v2.2.0, the SDK was versioned as follows:
@@ -192,4 +192,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.6.0
+[version]: 2.7.0

--- a/doc/README.md
+++ b/doc/README.md
@@ -93,6 +93,11 @@ Launches Smartcar Connect in a new window.
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
 | [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 | [options.singleSelect] | <code>Boolean</code> \| <code>Object</code> |  | An optional value that sets the behavior of the grant dialog displayed to the user. If set to `true`, `single_select` limits the user to selecting only one vehicle. If `single_select` is passed in as an object with the property `vin`, Smartcar will only authorize the vehicle with the specified VIN. See the [Single Select guide](https://smartcar.com/docs/guides/single-select/) for more information. |
+| [options.windowOptions] | <code>Object</code> |  | the position and dimension settings of the popup window |
+| [options.windowOptions.top] | <code>String</code> |  | the top property of [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features) |
+| [options.windowOptions.left] | <code>String</code> |  | the left property of [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features) |
+| [options.windowOptions.width] | <code>String</code> |  | the width property of [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features) |
+| [options.windowOptions.height] | <code>String</code> |  | the height property of [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features) |
 
 <a name="Smartcar+addClickHandler"></a>
 
@@ -106,7 +111,8 @@ On-click event calls openDialog when the specified element is clicked.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | clickHandler configuration object |
-| options.id | <code>String</code> |  | id of the element to add click handler to |
+| [options.id] | <code>String</code> |  | id of the element to add click handler to |
+| [options.selector] | <code>String</code> |  | css selector of the element(s) to add click handler to |
 | [options.state] | <code>String</code> |  | arbitrary state passed to redirect uri |
 | [options.forcePrompt] | <code>Boolean</code> | <code>false</code> | force permission approval screen to show on every authentication, even if the user has previously consented to the exact scope of permission |
 | [options.vehicleInfo.make] | <code>String</code> |  | `vehicleInfo` is an object with an optional property `make`, which allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
@@ -115,11 +121,17 @@ On-click event calls openDialog when the specified element is clicked.
 <a name="Smartcar+unmount"></a>
 
 ### smartcar.unmount()
-Remove Smartcar's listeners on the global window object.
+Remove Smartcar's event listeners.
 
+1. remove listener on the global window object:
 The Smartcar SDK uses a global 'message' event listener to recieve the
 authorization code from the pop-up dialog. Call this method to remove the
 event listener from the global window.
+
+2. remove click event listeners on DOM elements
+The Smartcar SDK also provides an `addClickHandler` method to attach click
+events to DOM elements. These event listeners will also be removed by calling
+this `unmount` method.
 
 **Kind**: instance method of [<code>Smartcar</code>](#Smartcar)
 <a name="Smartcar.AccessDenied"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -165,20 +165,20 @@ class Smartcar {
 
   /**
    * Calculate popup window size and position based on current window settings.
-   * 
+   *
    * @param {Object} options - the postion and dimention setting of the popup window
-   * @param {String} [options.top] - the top property of 
+   * @param {String} [options.top] - the top property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.left] - the left property of 
+   * @param {String} [options.left] - the left property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.width] - the width property of 
+   * @param {String} [options.width] - the width property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.height] - the height property of 
+   * @param {String} [options.height] - the height property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @private
    * @return {String} a string of window settings
    */
-  static _getWindowOptions({ top, left, width, height}) {
+  static _getWindowOptions({top, left, width, height}) {
     // Sets default popup window size as percentage of screen size
     // Note that this only applies to desktop browsers
     const windowSettings = {
@@ -310,13 +310,13 @@ class Smartcar {
    * for more information.
    * @param {Object} [options.windowOptions] - the position and dimension settings
    * of the popup window
-   * @param {String} [options.windowOptions.top] - the top property of 
+   * @param {String} [options.windowOptions.top] - the top property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.windowOptions.left] - the left property of 
+   * @param {String} [options.windowOptions.left] - the left property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.windowOptions.width] - the width property of 
+   * @param {String} [options.windowOptions.width] - the width property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
-   * @param {String} [options.windowOptions.height] - the height property of 
+   * @param {String} [options.windowOptions.height] - the height property of
    * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    */
   openDialog(options) {
@@ -352,23 +352,28 @@ class Smartcar {
    * for more information.
    */
   addClickHandler(options) {
-    const { id, selector } = options;
+    const {id, selector} = options;
     if (!id && !selector) {
-      throw new Error(`Could not add click handler: both id and selector are not passed in.`);
+      throw new Error('Could not add click handler: both id and selector are not passed in.');
     }
 
     // event listener will be added to all of the DOM elements that matches the id and selector.
     this._elements = [];
     if (id) {
-      this._elements.push(document.getElementById(id));
+      const element = document.getElementById(id);
+      if (element) {
+        this._elements.push(element);
+      }
       delete options.id;
-    } 
+    }
     if (selector) {
       this._elements.push(...document.querySelectorAll(selector));
       delete options.selector;
     }
     if (!this._elements.length) {
-      throw new Error(`Could not add click handler: element with '${id || selector}' was not found.`);
+      throw new Error(`
+        Could not add click handler: element with '${id || selector}' was not found.
+      `);
     }
 
     this._clickHandler = () => {
@@ -377,9 +382,9 @@ class Smartcar {
       // event.preventDefault();
       // event.stopPropogation();
       return false;
-    }
+    };
 
-    this._elements.forEach(element => element.addEventListener('click', this._clickHandler));
+    this._elements.forEach((element) => element.addEventListener('click', this._clickHandler));
   }
 
   /**
@@ -389,16 +394,16 @@ class Smartcar {
    * The Smartcar SDK uses a global 'message' event listener to recieve the
    * authorization code from the pop-up dialog. Call this method to remove the
    * event listener from the global window.
-   * 
+   *
    * 2. remove click event listeners on DOM elements
-   * The Smartcar SDK also provides an `addClickHandler` method to attach click 
+   * The Smartcar SDK also provides an `addClickHandler` method to attach click
    * events to DOM elements. These event listeners will also be removed by calling
    * this `unmount` method.
    */
   unmount() {
     window.removeEventListener('message', this.messageHandler);
     if (this._elements && this._elements.length) {
-      this._elements.forEach(element => element.removeEventListener('click', this._clickHandler));
+      this._elements.forEach((element) => element.removeEventListener('click', this._clickHandler));
     }
   }
 }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -168,13 +168,13 @@ class Smartcar {
    * 
    * @param {Object} options - the postion and dimention setting of the popup window
    * @param {String} [options.top] - the top property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.left] - the left property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.width] - the width property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.height] - the height property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @private
    * @return {String} a string of window settings
    */
@@ -311,13 +311,13 @@ class Smartcar {
    * @param {Object} [options.windowOptions] - the position and dimension settings
    * of the popup window
    * @param {String} [options.windowOptions.top] - the top property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.windowOptions.left] - the left property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.windowOptions.width] - the width property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @param {String} [options.windowOptions.height] - the height property of 
-   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    */
   openDialog(options) {
     const windowOptions = Smartcar._getWindowOptions(options.windowOptions || {});
@@ -333,7 +333,7 @@ class Smartcar {
    *
    * @param {Object} options - clickHandler configuration object
    * @param {String} [options.id] - id of the element to add click handler to
-   * @param {String} [options.selector] - css selector of the elements to add click handler to
+   * @param {String} [options.selector] - css selector of the element(s) to add click handler to
    * @param {String} [options.state] - arbitrary state passed to redirect uri
    * @param {Boolean} [options.forcePrompt=false] - force permission approval
    * screen to show on every authentication, even if the user has previously
@@ -357,7 +357,7 @@ class Smartcar {
       throw new Error(`Could not add click handler: both id and selector are not passed in.`);
     }
 
-    // event listener will be added to all of the DOM elements that matches the id/selector.
+    // event listener will be added to all of the DOM elements that matches the id and selector.
     this._elements = [];
     if (id) {
       this._elements.push(document.getElementById(id));

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -165,11 +165,20 @@ class Smartcar {
 
   /**
    * Calculate popup window size and position based on current window settings.
-   *
+   * 
+   * @param {Object} options - the postion and dimention setting of the popup window
+   * @param {String} [options.top] - the top property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.left] - the left property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.width] - the width property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.height] - the height property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    * @private
    * @return {String} a string of window settings
    */
-  static _getWindowOptions() {
+  static _getWindowOptions({ top, left, width, height}) {
     // Sets default popup window size as percentage of screen size
     // Note that this only applies to desktop browsers
     const windowSettings = {
@@ -177,14 +186,14 @@ class Smartcar {
       height: window.screen.height * 0.75,
     };
 
-    const width = (window.outerWidth - windowSettings.width) / 2;
-    const height = (window.outerHeight - windowSettings.height) / 8;
+    const widthOffset = (window.outerWidth - windowSettings.width) / 2;
+    const heightOffset = (window.outerHeight - windowSettings.height) / 8;
 
     let options = '';
-    options += `top=${window.screenY + height},`;
-    options += `left=${window.screenX + width},`;
-    options += `width=${windowSettings.width},`;
-    options += `height=${windowSettings.height},`;
+    options += `top=${top || window.screenY + heightOffset},`;
+    options += `left=${left || window.screenX + widthOffset},`;
+    options += `width=${width || windowSettings.width},`;
+    options += `height=${height || windowSettings.height},`;
 
     return options;
   }
@@ -299,10 +308,21 @@ class Smartcar {
    * the vehicle with the specified VIN. See the
    * [Single Select guide](https://smartcar.com/docs/guides/single-select/)
    * for more information.
+   * @param {Object} [options.windowOptions] - the position and dimension settings
+   * of the popup window
+   * @param {String} [options.windowOptions.top] - the top property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.windowOptions.left] - the left property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.windowOptions.width] - the width property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+   * @param {String} [options.windowOptions.height] - the height property of 
+   * [window feature](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
    */
   openDialog(options) {
+    const windowOptions = Smartcar._getWindowOptions(options.windowOptions || {});
+    delete options.windowOptions;
     const href = this.getAuthUrl(options);
-    const windowOptions = Smartcar._getWindowOptions();
     window.open(href, 'Connect your car', windowOptions);
   }
 


### PR DESCRIPTION
- update `addClickHandler` to receive css selector in addition to id
- remove click eventListeners that are added by `addClickHandler` in the unmount method
- add options to customize [window features](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features), including top, left, width, and height, of the pop up window