### PR TITLE
chore(ci): fix release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ jobs:
         - npm test
         - npm run cover
         - bash <(curl -s https://codecov.io/bash)
-        - git clone --mirror https://github.com/smartcar/javascript-sdk.git
-        - npx semantic-release --branch "$TRAVIS_BRANCH" --extends ./build/sr-configs/verify.js --repository-url ./javascript-sdk.git
+        - npx semantic-release --branches "$TRAVIS_BRANCH" --extends ./build/sr-configs/verify.js
     - stage: publish
       node_js: '16'
       if: branch = master

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cover": "npm test -- --coverage",
     "readme": "gulp template:readme",
     "jsdoc": "jsdoc2md --example-lang js --template doc/.template.hbs --files src/sdk.js | sed 's/[ \t]*$//' > doc/README.md",
-    "prepare-release": "semantic-release --branch \"$(git rev-parse --abbrev-ref HEAD)\" --extends ./build/sr-configs/local.js"
+    "prepare-release": "semantic-release --branches \"$(git rev-parse --abbrev-ref HEAD)\" --extends ./build/sr-configs/local.js"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
semantic-release's --branch flag got renamed to --branches
and it seems like we no longer need to do the mirror clone of the repo
