### PR TITLE
chore: fixed redirect uri dead link

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -191,7 +191,7 @@ class Smartcar {
       if (usesOldUriScheme) {
         // eslint-disable-next-line no-console
         console.warn(
-          "\nThe Smartcar redirect URI you're using is outdated! To update it, please see:\nhttps://smartcar.com/docs/guides/new-redirect-uri\n",
+          "\nThe Smartcar redirect URI you're using is outdated! To update it, please see:\nhttps://github.com/smartcar/javascript-sdk#1-register-a-javascript-sdk-redirect-uri\n",
         );
       }
     }


### PR DESCRIPTION
While updating the getting started, I noticed one of the console warning messages lead me to a dead link. I updated it with the link I found on the website. It might not be the exact link though.  

Another link I found with information is this one:
[smartcar docs link](https://smartcar.com/docs/tutorials/react/setup/#3-configure-your-redirect-uri)

Asana: https://app.asana.com/0/1202541891776753/1202657051601635/f