### PR TITLE
feat: add and pass `virtualKeyUrl` param to onComplete handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.9.0/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.10.0/sdk.js"></script>
 ```
 
 ## SDK reference
@@ -178,4 +178,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.9.0
+[version]: 2.10.0

--- a/doc/README.md
+++ b/doc/README.md
@@ -203,6 +203,7 @@ Invalid subscription error returned by Connect.
 | error | <code>Error</code> | something went wrong in Connect; this normally indicates that the user denied access to your application or does not have a connected vehicle |
 | code | <code>String</code> | the authorization code to be exchanged from a backend sever for an access token |
 | [state] | <code>Object</code> | contains state if it was set on the initial authorization request |
+| [virtualKeyUrl] | <code>String</code> | virtual key URL used by Tesla to register Smartcar's virtual key on a vehicle. This registration will be required in order to use any commands on a Tesla vehicle. It is an optional argument as it is only included in specific cases. |
 
 <a name="WindowOptions"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretest": "gulp build",
     "test": "jest",
     "posttest": "npm run lint -s",
-    "lint": "eslint . --cache",
+    "lint": "eslint . --cache --fix",
     "cover": "npm test -- --coverage",
     "readme": "gulp template:readme",
     "jsdoc": "jsdoc2md --example-lang js --template doc/.template.hbs --files src/sdk.js | sed 's/[ \t]*$//' > doc/README.md",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretest": "gulp build",
     "test": "jest",
     "posttest": "npm run lint -s",
-    "lint": "eslint . --cache --fix",
+    "lint": "eslint . --cache",
     "cover": "npm test -- --coverage",
     "readme": "gulp template:readme",
     "jsdoc": "jsdoc2md --example-lang js --template doc/.template.hbs --files src/sdk.js | sed 's/[ \t]*$//' > doc/README.md",

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -33,6 +33,7 @@
     make: params.get('make'),
     model: params.get('model'),
     year: params.get('year'),
+    virtualKeyUrl: params.get('virtual_key_url'),
   };
 
   // if no `app_origin` given, post to same origin as redirect page (assuming

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -12,6 +12,10 @@ class Smartcar {
    * backend sever for an access token
    * @param {Object} [state] - contains state if it was set on the initial
    * authorization request
+   * @param {String} [virtualKeyUrl] - virtual key URL used by Tesla to register
+   * Smartcar's virtual key on a vehicle. This registration will be required in order to use
+   * any commands on a Tesla vehicle. It is an optional argument as it is only included in
+   * specific cases.
    */
 
   /**
@@ -89,6 +93,8 @@ class Smartcar {
         return;
       }
 
+
+
       const {originalState, instanceId} = stateObject;
       // bail if `instanceId` doesn't match
       if (instanceId !== this.instanceId) {
@@ -138,6 +144,8 @@ class Smartcar {
 
         const err = generateError(message.error, message.errorDescription);
 
+        const virtualKeyUrl = message.virtualKeyUrl;
+
         /**
          * Call `onComplete` with parameters even if developer is not using
          * a Smartcar-hosted redirect. Regardless of if they are using a
@@ -150,7 +158,7 @@ class Smartcar {
          * parameters they must also handle populating the corresponding query
          * parameters in their redirect uri.
          */
-        this.onComplete(err, message.code, originalState);
+        this.onComplete(err, message.code, originalState, virtualKeyUrl);
       }
     };
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -93,8 +93,6 @@ class Smartcar {
         return;
       }
 
-
-
       const {originalState, instanceId} = stateObject;
       // bail if `instanceId` doesn't match
       if (instanceId !== this.instanceId) {

--- a/test/unit/redirect.test.js
+++ b/test/unit/redirect.test.js
@@ -96,6 +96,7 @@ describe('redirect', () => {
         model: null,
         vin: null,
         year: null,
+        virtualKeyUrl: null,
       },
       selfHostedOrigin,
     );
@@ -125,6 +126,7 @@ describe('redirect', () => {
         model: null,
         vin: null,
         year: null,
+        virtualKeyUrl: null,
       },
       appOrigin,
     );
@@ -142,6 +144,7 @@ describe('redirect', () => {
     const make = 'BMW';
     const model = 'M3';
     const year = '2013';
+    const virtualKeyUrl = 'https://www.tesla.com/_ak/smartcar.com';
 
     const params = new URLSearchParams();
     params.set('code', code);
@@ -152,6 +155,7 @@ describe('redirect', () => {
     params.set('make', make);
     params.set('model', model);
     params.set('year', year);
+    params.set('virtual_key_url', virtualKeyUrl);
 
     const cdnOrigin = `${CDN_ORIGIN}/redirect?app_origin=${appOrigin}&${params.toString()}`;
 
@@ -173,6 +177,7 @@ describe('redirect', () => {
         model,
         vin,
         year,
+        virtualKeyUrl,
       },
       appOrigin,
     );

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -360,8 +360,41 @@ describe('sdk', () => {
 
         smartcar.messageHandler(event);
 
-        expect(smartcar.onComplete).toBeCalledWith(null, expect.anything(), expect.anything());
+        expect(smartcar.onComplete).toBeCalledWith(
+          null,
+          expect.anything(),
+          expect.anything(),
+          undefined,
+        );
       });
+
+    test('fires onComplete with virtualKeyUrl when included', () => {
+      const options = {
+        clientId: 'clientId',
+        redirectUri: `${CDN_ORIGIN}?app_origin=https://app.com`,
+        scope: ['read_vehicle_info', 'read_odometer'],
+        // eslint-disable-next-line no-unused-vars, no-empty-function
+        onComplete: jest.fn((__, _) => {}),
+      };
+
+      const smartcar = new Smartcar(options);
+
+      const event = {
+        data: {
+          name: 'SmartcarAuthMessage',
+          isSmartcarHosted: true,
+          code: 'super-secret-code',
+          errorDescription: 'this doesnt matter',
+          state: getEncodedState(smartcar.instanceId, 'some-state'),
+          virtualKeyUrl: 'https://www.tesla.com/_ak/smartcar.com',
+        },
+        origin: CDN_ORIGIN,
+      };
+
+      smartcar.messageHandler(event);
+
+      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state', 'https://www.tesla.com/_ak/smartcar.com');
+    });
 
     test('fires onComplete w/o error when error: null in postMessage', () => {
       const options = {
@@ -387,7 +420,7 @@ describe('sdk', () => {
 
       smartcar.messageHandler(event);
 
-      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state');
+      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state', undefined);
     });
 
     test('fires onComplete w/o error when error key not in postMessage', () => {
@@ -414,7 +447,7 @@ describe('sdk', () => {
 
       smartcar.messageHandler(event);
 
-      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state');
+      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state', undefined);
     });
 
     test(// eslint-disable-next-line max-len
@@ -456,6 +489,7 @@ describe('sdk', () => {
           new Smartcar.VehicleIncompatible(errorDescription, vehicleInfo),
           'super-secret-code',
           'some-state',
+          undefined,
         );
       });
 
@@ -601,6 +635,7 @@ describe('sdk', () => {
           new Smartcar.AccessDenied(errorDescription),
           'super-secret-code',
           'some-state',
+          undefined,
         );
       });
 
@@ -635,6 +670,7 @@ describe('sdk', () => {
           new Smartcar.InvalidSubscription(errorDescription),
           'super-secret-code',
           'some-state',
+          undefined,
         );
       });
 
@@ -670,6 +706,7 @@ describe('sdk', () => {
           Error(`Unexpected error: ${error} - ${errorDescription}`),
           'super-secret-code',
           'some-state',
+          undefined,
         );
       });
   });


### PR DESCRIPTION
For brands that require a virtual key to be registered on the vehicle in order to receive data and/or send commands to the vehicle, Smartcar will be sending back an additional query parameter, `virutal_key_url`, when redirecting back with the authorization `code`. This PR:
1. includes the value of the `virtual_key_url` in the message that is `postMessage`'d back to the origin
2. updates the interface of the `onComplete` to include a new parameter, `virtualKeyUrl`
3. and passes the value of the `virtualKeyUrl` property on the `message` object to the `onComplete` function.

From there, the `virtualKeyUrl` can be used within the `onComplete` that is created by the developer, and passed onto the BE, etc. so that it can be sent to the appropriate vehicle owners.