### PR TITLE
feat(eng-1231): support directless connect

### DIFF
--- a/.buddy/deploy-cdn.yml
+++ b/.buddy/deploy-cdn.yml
@@ -25,4 +25,5 @@
     execute_commands:
     - npx gulp build:cdn
     - npx gulp publish:cdn
+    - aws cloudfront create-invalidation --distribution-id E31YSGLVNQFV7R --paths "/v2/redirect.js"
     region: us-west-2

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.13.1
+[version]: 2.14.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The official Smartcar JavaScript SDK.
 The [Smartcar API](https://smartcar.com/docs) lets you read vehicle data
 (location, odometer) and send commands to vehicles (lock, unlock) using HTTP requests.
 
-To make requests to a vehicle from a web application, the end user must connect their vehicle using [Smartcar Connect](https://smartcar.com/docs/api#smartcar-connect). The Smartcar JavaScript SDK provides an easy way to launch and handle Connect to retrieve the resulting `code`.
+To make requests to a vehicle from a web application, the end user must connect their vehicle using [Smartcar Connect](https://smartcar.com/docs/connect/what-is-connect). The Smartcar JavaScript SDK provides an easy way to launch and handle Connect to retrieve the resulting `code`, or to complete a redirect-less M2M authorization flow using `response_type=none`.
 
 Before integrating with the JavaScript SDK, you'll need to register an application in the [Smartcar dashboard](https://dashboard.smartcar.com). Once you have registered an application, you will have an Application ID, which will allow you to launch Connect and authorize users.
 
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.13.1/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.14.0/sdk.js"></script>
 ```
 
 ## SDK reference
@@ -131,6 +131,34 @@ const url = smartcar.getAuthUrl();
 ```
 
 **Reference:** [`smartcar.getAuthUrl(options)`](doc#Smartcar+getAuthUrl)
+
+### response_type=none flow
+
+For M2M use cases, you can launch Connect with `responseType: 'none'` to complete authorization without exchanging the authorization code in the browser. This mode is intended for M2M Auth flow that does not require a vehicle-scope authorization code.
+
+If you provide a `redirectUri`, Connect redirects the user after authorization completes and `onComplete` fires as normal. If you do not provide a `redirectUri`, the user lands on a Smartcar-hosted page after authorization completes.
+
+It is recommended that you pass an `externalId` to associate the vehicle connection with an identifier in your system. It will be returned in the `onComplete` callback.
+
+```javascript
+const smartcar = new Smartcar({
+  applicationId: '<your-application-id>',
+  scope: ['read_vehicle_info', 'read_odometer'],
+  redirectUri: '<your-redirect-uri>'
+  responseType: 'none',
+  externalId: '<your-external-id>',
+});
+```
+
+Launch Connect as usual:
+
+```javascript
+smartcar.openDialog();
+```
+
+Use `externalId` to correlate the completed authorization with a user in your system in webhook delivieres or by making a request to the `/connections` endpoint filtered by the user's `externalId`.
+
+**Reference:** [`new Smartcar(options)`](doc#new_Smartcar_new)
 
 ### Server-side redirect handling
 

--- a/README.mdt
+++ b/README.mdt
@@ -7,7 +7,7 @@ The official Smartcar JavaScript SDK.
 The [Smartcar API](https://smartcar.com/docs) lets you read vehicle data
 (location, odometer) and send commands to vehicles (lock, unlock) using HTTP requests.
 
-To make requests to a vehicle from a web application, the end user must connect their vehicle using [Smartcar Connect](https://smartcar.com/docs/api#smartcar-connect). The Smartcar JavaScript SDK provides an easy way to launch and handle Connect to retrieve the resulting `code`.
+To make requests to a vehicle from a web application, the end user must connect their vehicle using [Smartcar Connect](https://smartcar.com/docs/connect/what-is-connect). The Smartcar JavaScript SDK provides an easy way to launch and handle Connect to retrieve the resulting `code`, or to complete a redirect-less M2M authorization flow using `response_type=none`.
 
 Before integrating with the JavaScript SDK, you'll need to register an application in the [Smartcar dashboard](https://dashboard.smartcar.com). Once you have registered an application, you will have an Application ID, which will allow you to launch Connect and authorize users.
 
@@ -131,6 +131,34 @@ const url = smartcar.getAuthUrl();
 ```
 
 **Reference:** [`smartcar.getAuthUrl(options)`](doc#Smartcar+getAuthUrl)
+
+### response_type=none flow
+
+For M2M use cases, you can launch Connect with `responseType: 'none'` to complete authorization without exchanging the authorization code in the browser. This mode is intended for M2M Auth flow that does not require a vehicle-scope authorization code.
+
+If you provide a `redirectUri`, Connect redirects the user after authorization completes and `onComplete` fires as normal. If you do not provide a `redirectUri`, the user lands on a Smartcar-hosted page after authorization completes.
+
+It is recommended that you pass an `externalId` to associate the vehicle connection with an identifier in your system. It will be returned in the `onComplete` callback.
+
+```javascript
+const smartcar = new Smartcar({
+  applicationId: '<your-application-id>',
+  scope: ['read_vehicle_info', 'read_odometer'],
+  redirectUri: '<your-redirect-uri>'
+  responseType: 'none',
+  externalId: '<your-external-id>',
+});
+```
+
+Launch Connect as usual:
+
+```javascript
+smartcar.openDialog();
+```
+
+Use `externalId` to correlate the completed authorization with a user in your system in webhook delivieres or by making a request to the `/connections` endpoint filtered by the user's `externalId`.
+
+**Reference:** [`new Smartcar(options)`](doc#new_Smartcar_new)
 
 ### Server-side redirect handling
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -57,7 +57,7 @@ Initializes Smartcar class.
 | [options.testMode] | <code>Boolean</code> | <code>false</code> | Deprecated, please use `mode` instead. Launch Smartcar Connect in [test mode](https://smartcar.com/docs/guides/testing/). |
 | [options.mode] | <code>String</code> | <code>&#x27;live&#x27;</code> | Determine what mode Smartcar Connect should be launched in. Should be one of test, live or simulated. |
 | [options.responseType] | <code>String</code> | <code>&#x27;code&#x27;</code> | OAuth response type. Use 'none' for redirect-less M2M flows; defaults to 'code'. |
-| [options.externalId] | <code>String</code> |  | An optional external identifier passed through to Connect and returned in the onComplete callback. |
+| [options.externalId] | <code>String</code> |  | An optional external identifier passed through to Connect and returned in the onComplete callback. Pass `null` to explicitly clear a previously set externalId; omit the option (`undefined`) to leave it unset. |
 
 <a name="Smartcar+getAuthUrl"></a>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -56,6 +56,8 @@ Initializes Smartcar class.
 | [options.onComplete] | [<code>OnComplete</code>](#OnComplete) |  | called on completion of Smartcar Connect |
 | [options.testMode] | <code>Boolean</code> | <code>false</code> | Deprecated, please use `mode` instead. Launch Smartcar Connect in [test mode](https://smartcar.com/docs/guides/testing/). |
 | [options.mode] | <code>String</code> | <code>&#x27;live&#x27;</code> | Determine what mode Smartcar Connect should be launched in. Should be one of test, live or simulated. |
+| [options.responseType] | <code>String</code> | <code>&#x27;code&#x27;</code> | OAuth response type. Use `'none'` for redirect-less M2M flows. Must be one of `'code'` or `'none'`. |
+| [options.externalId] | <code>String</code> |  | An optional external identifier passed through to Connect and returned in the onComplete callback. |
 
 <a name="Smartcar+getAuthUrl"></a>
 
@@ -204,10 +206,11 @@ Invalid subscription error returned by Connect.
 | Param | Type | Description |
 | --- | --- | --- |
 | error | <code>Error</code> | something went wrong in Connect; this normally indicates that the user denied access to your application or does not have a connected vehicle |
-| code | <code>String</code> | the authorization code to be exchanged from a backend sever for an access token |
+| [code] | <code>String</code> | the authorization code to be exchanged from a backend server for an access token; `undefined` for `response_type=none` flows |
 | [state] | <code>Object</code> | contains state if it was set on the initial authorization request |
 | [virtualKeyUrl] | <code>String</code> | virtual key URL used by Tesla to register Smartcar's virtual key on a vehicle. This registration will be required in order to use any commands on a Tesla vehicle. It is an optional argument as it is only included in specific cases. |
-| userId | <code>String</code> | A unique identifier for the vehicle owner that granted access. |
+| userId | <code>String</code> | A unique Smartcar identifier for the vehicle owner that granted access. |
+| [externalId] | <code>String</code> | The external_id returned by Connect. |
 
 <a name="WindowOptions"></a>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -56,7 +56,7 @@ Initializes Smartcar class.
 | [options.onComplete] | [<code>OnComplete</code>](#OnComplete) |  | called on completion of Smartcar Connect |
 | [options.testMode] | <code>Boolean</code> | <code>false</code> | Deprecated, please use `mode` instead. Launch Smartcar Connect in [test mode](https://smartcar.com/docs/guides/testing/). |
 | [options.mode] | <code>String</code> | <code>&#x27;live&#x27;</code> | Determine what mode Smartcar Connect should be launched in. Should be one of test, live or simulated. |
-| [options.responseType] | <code>String</code> | <code>&#x27;code&#x27;</code> | OAuth response type. Use `'none'` for redirect-less M2M flows. Must be one of `'code'` or `'none'`. |
+| [options.responseType] | <code>String</code> | <code>&#x27;code&#x27;</code> | OAuth response type. Use 'none' for redirect-less M2M flows; defaults to 'code'. |
 | [options.externalId] | <code>String</code> |  | An optional external identifier passed through to Connect and returned in the onComplete callback. |
 
 <a name="Smartcar+getAuthUrl"></a>
@@ -206,10 +206,10 @@ Invalid subscription error returned by Connect.
 | Param | Type | Description |
 | --- | --- | --- |
 | error | <code>Error</code> | something went wrong in Connect; this normally indicates that the user denied access to your application or does not have a connected vehicle |
-| [code] | <code>String</code> | the authorization code to be exchanged from a backend server for an access token; `undefined` for `response_type=none` flows |
+| [code] | <code>String</code> | the authorization code to be exchanged from a backend server for an access token; undefined for response_type=none flows |
 | [state] | <code>Object</code> | contains state if it was set on the initial authorization request |
 | [virtualKeyUrl] | <code>String</code> | virtual key URL used by Tesla to register Smartcar's virtual key on a vehicle. This registration will be required in order to use any commands on a Tesla vehicle. It is an optional argument as it is only included in specific cases. |
-| userId | <code>String</code> | A unique Smartcar identifier for the vehicle owner that granted access. |
+| userId | <code>String</code> | A unique identifier for the vehicle owner that granted access. |
 | [externalId] | <code>String</code> | The external_id returned by Connect. |
 
 <a name="WindowOptions"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -35,8 +35,11 @@
     year: params.get('year'),
     virtualKeyUrl: params.get('virtual_key_url'),
     userId: params.get('user_id'),
-    externalId: params.get('external_id'),
   };
+
+  if (params.has('external_id')) {
+    message.externalId = params.get('external_id');
+  }
 
   // if no `app_origin` given, post to same origin as redirect page (assuming
   // server side rendered architecture)

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -35,6 +35,7 @@
     year: params.get('year'),
     virtualKeyUrl: params.get('virtual_key_url'),
     userId: params.get('user_id'),
+    externalId: params.get('external_id'),
   };
 
   // if no `app_origin` given, post to same origin as redirect page (assuming

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -10,8 +10,8 @@ class Smartcar {
    * @param {?Error} error - something went wrong in Connect; this
    * normally indicates that the user denied access to your application or does not
    * have a connected vehicle
-   * @param {String} code - the authorization code to be exchanged from a
-   * backend sever for an access token
+   * @param {String} [code] - the authorization code to be exchanged from a
+   * backend server for an access token; undefined for response_type=none flows
    * @param {Object} [state] - contains state if it was set on the initial
    * authorization request
    * @param {String} [virtualKeyUrl] - virtual key URL used by Tesla to register
@@ -19,6 +19,7 @@ class Smartcar {
    * any commands on a Tesla vehicle. It is an optional argument as it is only included in
    * specific cases.
    * @param {String} userId - A unique identifier for the vehicle owner that granted access.
+   * @param {String} [externalId] - The external_id returned by Connect.
    */
 
   /**
@@ -36,6 +37,10 @@ class Smartcar {
    * Launch Smartcar Connect in [test mode](https://smartcar.com/docs/guides/testing/).
    * @param {String} [options.mode='live'] - Determine what mode Smartcar Connect should be
    * launched in. Should be one of test, live or simulated.
+   * @param {String} [options.responseType='code'] - OAuth response type. Use 'none' for
+   * redirect-less M2M flows; defaults to 'code'.
+   * @param {String} [options.externalId] - An optional external identifier passed through
+   * to Connect and returned in the onComplete callback.
  */
   constructor(options) {
     // polyfill String.prototype.startsWith for IE11 support
@@ -80,7 +85,8 @@ class Smartcar {
         'The "mode" parameter MUST be one of the following: \'test\', \'live\', \'simulated\'',
       );
     }
-    this.responseType = 'code';
+    this.responseType = options.responseType || 'code';
+    this.externalId = options.externalId;
     // identifier for matching message event and multiple Smartcar instances
     // it is a string composed of a timestamp and a 8-digit random number
     this.instanceId = (new Date()).getTime() + String(Math.random()).slice(2, 10);
@@ -160,6 +166,8 @@ class Smartcar {
 
         const userId = message.userId;
 
+        const externalId = message.externalId;
+
         /**
          * Call `onComplete` with parameters even if developer is not using
          * a Smartcar-hosted redirect. Regardless of if they are using a
@@ -172,7 +180,7 @@ class Smartcar {
          * parameters they must also handle populating the corresponding query
          * parameters in their redirect uri.
          */
-        this.onComplete(err, message.code, originalState, virtualKeyUrl, userId);
+        this.onComplete(err, message.code, originalState, virtualKeyUrl, userId, externalId);
       }
     };
 
@@ -191,6 +199,13 @@ class Smartcar {
   static _validateConstructorOptions(options) {
     if (!options.applicationId && !options.clientId) {
       throw new TypeError('An applicationId option must be provided');
+    }
+
+    const VALID_RESPONSE_TYPES = ['code', 'none'];
+    if (options.responseType && !VALID_RESPONSE_TYPES.includes(options.responseType)) {
+      throw new Error(
+        `The "responseType" option must be one of: ${VALID_RESPONSE_TYPES.join(', ')}`,
+      );
     }
 
     if (options.redirectUri) {
@@ -380,6 +395,10 @@ class Smartcar {
       link += `&user=${encodeURIComponent(options.user)}`;
     }
 
+    if (this.externalId) {
+      link += `&external_id=${encodeURIComponent(this.externalId)}`;
+    }
+
     return link;
   }
 
@@ -409,6 +428,7 @@ class Smartcar {
    * the popup window
    */
   openDialog(options) {
+    options = options || {};
     const windowOptions = Smartcar._getWindowOptions(options.windowOptions || {});
     const href = this.getAuthUrl(options);
     window.open(href, 'Connect your car', windowOptions);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -229,6 +229,11 @@ class Smartcar {
           );
         }
       }
+    } else if (options.responseType === 'none' && options.onComplete) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The "onComplete" callback will not fire for responseType "none" unless a redirectUri is provided.',
+      );
     }
 
   }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -40,7 +40,8 @@ class Smartcar {
    * @param {String} [options.responseType='code'] - OAuth response type. Use 'none' for
    * redirect-less M2M flows; defaults to 'code'.
    * @param {String} [options.externalId] - An optional external identifier passed through
-   * to Connect and returned in the onComplete callback.
+   * to Connect and returned in the onComplete callback. Pass `null` to explicitly clear a
+   * previously set externalId; omit the option (`undefined`) to leave it unset.
  */
   constructor(options) {
     // polyfill String.prototype.startsWith for IE11 support
@@ -400,8 +401,11 @@ class Smartcar {
       link += `&user=${encodeURIComponent(options.user)}`;
     }
 
-    if (this.externalId) {
-      link += `&external_id=${encodeURIComponent(this.externalId)}`;
+    if (this.externalId !== undefined) {
+      const externalId = this.externalId === null
+        ? 'null'
+        : encodeURIComponent(this.externalId);
+      link += `&external_id=${externalId}`;
     }
 
     return link;

--- a/test/unit/redirect.test.js
+++ b/test/unit/redirect.test.js
@@ -148,6 +148,7 @@ describe('redirect', () => {
     const year = '2013';
     const virtualKeyUrl = 'https://www.tesla.com/_ak/smartcar.com';
     const userId = 'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c';
+    const externalId = 'external-id-from-connect';
 
     const params = new URLSearchParams();
     params.set('code', code);
@@ -160,6 +161,7 @@ describe('redirect', () => {
     params.set('year', year);
     params.set('virtual_key_url', virtualKeyUrl);
     params.set('user_id', userId);
+    params.set('external_id', externalId);
 
     const cdnOrigin = `${CDN_ORIGIN}/redirect?app_origin=${appOrigin}&${params.toString()}`;
 
@@ -183,6 +185,7 @@ describe('redirect', () => {
         year,
         virtualKeyUrl,
         userId,
+        externalId,
       },
       appOrigin,
     );

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -1303,6 +1303,54 @@ describe('sdk', () => {
     expect(link).toBe(expectedLink);
   });
 
+  test('generates link with externalId set to null to clear it', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      scope: ['read_vehicle_info', 'read_odometer'],
+      onComplete: jest.fn(),
+      externalId: null,
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    const expectedLink =
+      `https://connect.smartcar.com/oauth/authorize?response_type=code&application_id=applicationId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=auto&scope=read_vehicle_info%20read_odometer&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}&external_id=null`;
+    expect(link).toBe(expectedLink);
+  });
+
+  test('generates link with externalId set to \'null\' to clear it', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      scope: ['read_vehicle_info', 'read_odometer'],
+      onComplete: jest.fn(),
+      externalId: 'null',
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    const expectedLink =
+      `https://connect.smartcar.com/oauth/authorize?response_type=code&application_id=applicationId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=auto&scope=read_vehicle_info%20read_odometer&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}&external_id=null`;
+    expect(link).toBe(expectedLink);
+  });
+
+  test('generates link without externalId when not provided', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      scope: ['read_vehicle_info', 'read_odometer'],
+      onComplete: jest.fn(),
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    const expectedLink =
+      `https://connect.smartcar.com/oauth/authorize?response_type=code&application_id=applicationId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=auto&scope=read_vehicle_info%20read_odometer&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}`;
+    expect(link).not.toContain('external_id');
+    expect(link).toBe(expectedLink);
+  });
+
   test('generates link without redirectUri and scope', () => {
     const smartcar = new Smartcar({
       applicationId: 'applicationId',

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -1026,6 +1026,15 @@ describe('sdk', () => {
       );
     });
 
+    test('constructor errors on invalid responseType', () => {
+      expect(
+        () =>
+          new Smartcar({
+            applicationId: 'applicationId',
+            responseType: 'invalid',
+          }),
+      ).toThrow('The "responseType" option must be one of: code, none');
+    });
 
     test('generate link when vehicleInfo={...} included', () => {
       const options = {
@@ -1278,6 +1287,22 @@ describe('sdk', () => {
     expect(link).toBe(expectedLink);
   });
 
+  test('generates link with externalId', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      scope: ['read_vehicle_info', 'read_odometer'],
+      onComplete: jest.fn(),
+      externalId: 'test-external-id',
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    const expectedLink =
+      `https://connect.smartcar.com/oauth/authorize?response_type=code&application_id=applicationId&redirect_uri=https%3A%2F%2Fsmartcar.com&approval_prompt=auto&scope=read_vehicle_info%20read_odometer&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}&external_id=test-external-id`;
+    expect(link).toBe(expectedLink);
+  });
+
   test('generates link without redirectUri and scope', () => {
     const smartcar = new Smartcar({
       applicationId: 'applicationId',
@@ -1324,6 +1349,16 @@ describe('sdk', () => {
       });
 
       smartcar.openDialog(dialogOptions);
+      expect(window.open).toHaveBeenCalled();
+    });
+
+    test('openDialog works when called without arguments', () => {
+      const mockOpen = jest.fn();
+      window.open = mockOpen;
+
+      const smartcar = new Smartcar(options);
+      smartcar.openDialog();
+
       expect(window.open).toHaveBeenCalled();
     });
 

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -138,7 +138,7 @@ describe('sdk', () => {
     });
 
     test('warns when responseType is none and no redirectUri is provided with onComplete', () => {
-      const spy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+      const spy = jest.spyOn(global.console, 'warn').mockImplementation();
 
       // eslint-disable-next-line no-new
       new Smartcar({
@@ -499,6 +499,7 @@ describe('sdk', () => {
           expect.anything(),
           undefined,
           'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+          undefined,
         );
       });
 
@@ -528,7 +529,7 @@ describe('sdk', () => {
 
       smartcar.messageHandler(event);
 
-      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state', 'https://www.tesla.com/_ak/smartcar.com', 'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c');
+      expect(smartcar.onComplete).toBeCalledWith(null, 'super-secret-code', 'some-state', 'https://www.tesla.com/_ak/smartcar.com', 'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c', undefined);
     });
 
     test('fires onComplete w/o error when error: null in postMessage', () => {
@@ -562,6 +563,7 @@ describe('sdk', () => {
         'some-state',
         undefined,
         'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+        undefined,
       );
     });
 
@@ -596,6 +598,7 @@ describe('sdk', () => {
         'some-state',
         undefined,
         'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+        undefined,
       );
     });
 
@@ -641,6 +644,7 @@ describe('sdk', () => {
           'some-state',
           undefined,
           'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+          undefined,
         );
       });
 
@@ -789,6 +793,7 @@ describe('sdk', () => {
           'some-state',
           undefined,
           'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+          undefined,
         );
       });
 
@@ -826,6 +831,7 @@ describe('sdk', () => {
           'some-state',
           undefined,
           'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+          undefined,
         );
       });
 
@@ -864,6 +870,7 @@ describe('sdk', () => {
           'some-state',
           undefined,
           'e9e10eb2-63d7-42ab-96fd-bbe7f4abff4c',
+          undefined,
         );
       });
   });

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -137,6 +137,23 @@ describe('sdk', () => {
       /* eslint-enable */
     });
 
+    test('warns when responseType is none and no redirectUri is provided with onComplete', () => {
+      const spy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+
+      // eslint-disable-next-line no-new
+      new Smartcar({
+        applicationId: 'my-id',
+        responseType: 'none',
+        onComplete: jest.fn(),
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'The "onComplete" callback will not fire for responseType "none" unless a redirectUri is provided.',
+      );
+
+      spy.mockRestore();
+    });
+
     test('initializes correctly w/ self hosted redirect', () => {
       const options = {
         applicationId: 'applicationId',


### PR DESCRIPTION
## Summary

Adds `responseType` and `externalId` support to the JavaScript SDK for M2M / redirect-less Connect flows.

- **`responseType: 'none'`** — passes `response_type=none` to Connect, enabling authorization without an authorization code exchange in the browser. Defaults to `'code'` (no behavior change for existing integrations).
- **`externalId`** — passes `external_id` as a URL parameter to Connect; `redirect.js` reads it back from the redirect URL and includes it in the `SmartcarAuthMessage` postMessage, where it surfaces as the 6th argument to `onComplete`.
- **`onComplete` warning** — when `responseType: 'none'` is used without a `redirectUri`, a `console.warn` fires at construction time to signal that `onComplete` will not be called (since Connect does not redirect to the SDK redirect page in the none flow).
- **`openDialog()` bugfix** — calling `openDialog()` without arguments previously threw a `TypeError`; fixed by defaulting `options` to `{}`.

## Changes

| File | What changed |
|------|-------------|
| `src/sdk.js` | Accept `responseType`/`externalId` options; validate `responseType`; append `external_id` to auth URL; surface `externalId` in `onComplete`; warn when `onComplete` won't fire; fix `openDialog()` no-args crash |
| `src/redirect.js` | Conditionally include `externalId` in postMessage payload when `external_id` is present in redirect URL params |
| `doc/README.md` | Document new constructor options and updated `onComplete` signature |
| `README.md` / `README.mdt` | Add overview mention of redirect-less flow; add `response_type=none` usage section in Advanced |

## Notes

- `redirect.js` is deployed to the major-version CDN path (`v2/redirect.js`) — a CloudFront cache invalidation for `/v2/redirect.js` is required after deploy for the `externalId` change to be live immediately.
- `onComplete` receives `externalId` as a new 6th argument; existing callbacks with fewer parameters are unaffected (JavaScript does not enforce arity).
- For `responseType: 'none'` flows without a `redirectUri`, the developer is expected to use `externalId` server-side to correlate the connection via webhook or the `/connections` endpoint.

## Tested locally:
Note: the external_id is undefined in these tests because the hosted redirect.js won't be deployed until after release.
1. response_type=none with redirect
received message with no code
<img width="1366" height="838" alt="image" src="https://github.com/user-attachments/assets/218de219-ec18-49fe-8728-6c81ce0879ab" />

2. response_type=none with no redirect
Received warning that onComplete will not fire
<img width="1540" height="896" alt="image" src="https://github.com/user-attachments/assets/7f1e8ad7-cb2b-41c5-a211-8d29c8f0e1d4" />

3. response_type=code
receives vehicle-scoped code
<img width="1540" height="896" alt="image" src="https://github.com/user-attachments/assets/8b1aff22-8279-46db-83f8-da311765ec7c" />
