### PR TITLE
fix: include app_origin to receive session complete 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @smartcar/auth
 ### Smartcar CDN
 
 ```html
-<script src="https://javascript-sdk.smartcar.com/2.14.0/sdk.js"></script>
+<script src="https://javascript-sdk.smartcar.com/2.14.1/sdk.js"></script>
 ```
 
 ## SDK reference
@@ -208,4 +208,4 @@ https://application-backend.com/page?error=access_denied&error_description=User+
 [tag-image]: https://img.shields.io/github/tag/smartcar/javascript-sdk.svg
 
 <!-- Please do not modify or remove this, it is used by the build process -->
-[version]: 2.14.0
+[version]: 2.14.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcar/auth",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "javascript auth sdk for the smartcar",
   "main": "dist/npm/sdk.js",
   "license": "MIT",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -230,13 +230,7 @@ class Smartcar {
           );
         }
       }
-    } else if (options.responseType === 'none' && options.onComplete) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'The "onComplete" callback will not fire for responseType "none" unless a redirectUri is provided.',
-      );
     }
-
   }
 
   /**
@@ -330,6 +324,7 @@ class Smartcar {
    * &flags=country:DE color:00819D
    * &user=2dad4eaf-9094-4bff-bb0f-ffbbdde8b562
    */
+  // eslint-disable-next-line complexity
   getAuthUrl(options) {
     options = options || {};
 
@@ -406,6 +401,10 @@ class Smartcar {
         ? 'null'
         : encodeURIComponent(this.externalId);
       link += `&external_id=${externalId}`;
+    }
+
+    if (this.responseType === 'none' && !this.redirectUri) {
+      link += `&app_origin=${encodeURIComponent(window.location.origin)}`;
     }
 
     return link;

--- a/test/unit/sdk.test.js
+++ b/test/unit/sdk.test.js
@@ -137,23 +137,6 @@ describe('sdk', () => {
       /* eslint-enable */
     });
 
-    test('warns when responseType is none and no redirectUri is provided with onComplete', () => {
-      const spy = jest.spyOn(global.console, 'warn').mockImplementation();
-
-      // eslint-disable-next-line no-new
-      new Smartcar({
-        applicationId: 'my-id',
-        responseType: 'none',
-        onComplete: jest.fn(),
-      });
-
-      expect(spy).toHaveBeenCalledWith(
-        'The "onComplete" callback will not fire for responseType "none" unless a redirectUri is provided.',
-      );
-
-      spy.mockRestore();
-    });
-
     test('initializes correctly w/ self hosted redirect', () => {
       const options = {
         applicationId: 'applicationId',
@@ -1362,6 +1345,45 @@ describe('sdk', () => {
     const expectedLink =
       `https://connect.smartcar.com/oauth/authorize?response_type=code&application_id=applicationId&approval_prompt=auto&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}`;
     expect(link).toBe(expectedLink);
+  });
+
+  test('generates link with app_origin when responseType is none', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      responseType: 'none',
+      externalId: 'test-external-id',
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    const expectedLink =
+      `https://connect.smartcar.com/oauth/authorize?response_type=none&application_id=applicationId&approval_prompt=auto&mode=live&state=${getEncodedDefaultState(smartcar.instanceId)}&external_id=test-external-id&app_origin=${encodeURIComponent(window.location.origin)}`;
+    expect(link).toBe(expectedLink);
+  });
+
+  test('generates link without app_origin when responseType is code', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      onComplete: jest.fn(),
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    expect(link).not.toContain('app_origin');
+  });
+
+  test('generates link without app_origin when responseType is none but redirectUri is set', () => {
+    const smartcar = new Smartcar({
+      applicationId: 'applicationId',
+      redirectUri: 'https://smartcar.com',
+      responseType: 'none',
+      onComplete: jest.fn(),
+    });
+
+    const link = smartcar.getAuthUrl();
+
+    expect(link).not.toContain('app_origin');
   });
 
   describe('openDialog and addClickHandler', () => {


### PR DESCRIPTION
When Connect is launched with response_type=none and no redirect_uri, the user would end in the popup and the onComplete callback does not fire. This patches that gap, Connect will post a message window, at the identified app_origin and close the popup whenever the Connect session completes
